### PR TITLE
Fix startup error related to upstream changes

### DIFF
--- a/tailscale/rootfs/etc/services.d/tailscaled/post
+++ b/tailscale/rootfs/etc/services.d/tailscaled/post
@@ -47,7 +47,7 @@ done
 while true;
 do
   if /opt/tailscale status --json --peers false --self false \
-    | jq --exit-status '.BackendState == "Running"';
+    | jq --exit-status '.BackendState == "Running" or .BackendState == "NeedsLogin"';
   then
     IFS=","
     /opt/tailscale up \


### PR DESCRIPTION
# Proposed Changes

Issue described in #79 is related to upstream services changes.
`BackendState` is set to `NeedsLogin` on initial add-on configuration, changes to `Running` after successful login. 
