### PR TITLE
Request TLS certificate for tailnet domain alias.

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -19,9 +19,6 @@ arch:
 init: false
 map:
   - ssl:rw
-options:
-  certfile: fullchain.pem
-  keyfile: privkey.pem
 hassio_api: true
 privileged:
   - NET_ADMIN
@@ -31,5 +28,3 @@ host_network: true
 schema:
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
   domain_alias: match(^[a-z0-9][a-z0-9\-_]{0,61}\.ts\.net$)?
-  certfile: str
-  keyfile: str

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -20,7 +20,6 @@ init: false
 map:
   - ssl:rw
 options:
-  request_cert: false
   certfile: fullchain.pem
   keyfile: privkey.pem
 hassio_api: true
@@ -31,7 +30,6 @@ devices:
 host_network: true
 schema:
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
-  request_cert: bool
   domain_alias: match(^[a-z0-9][a-z0-9\-_]{0,61}\.ts\.net$)?
   certfile: str
   keyfile: str

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -17,6 +17,12 @@ arch:
   - armv7
   - i386
 init: false
+map:
+  - ssl:rw
+options:
+  request_cert: false
+  certfile: fullchain.pem
+  keyfile: privkey.pem
 hassio_api: true
 privileged:
   - NET_ADMIN
@@ -25,3 +31,7 @@ devices:
 host_network: true
 schema:
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
+  request_cert: bool
+  domain_alias: match(^[a-z0-9][a-z0-9\-_]{0,61}\.ts\.net$)?
+  certfile: str
+  keyfile: str

--- a/tailscale/rootfs/etc/services.d/cert/finish
+++ b/tailscale/rootfs/etc/services.d/cert/finish
@@ -1,0 +1,9 @@
+#!/usr/bin/execlineb -S0
+# ==============================================================================
+# Home Assistant Community Add-on: Tailscale
+# Take down the S6 supervision tree when Tailscale cert fails
+# ==============================================================================
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/tailscale/rootfs/etc/services.d/cert/run
+++ b/tailscale/rootfs/etc/services.d/cert/run
@@ -8,8 +8,8 @@
 tailscale_cert() {
   if bashio::config.has_value 'domain_alias'; then
     /opt/tailscale cert \
-      --cert-file "/ssl/$(bashio::config 'certfile')" \
-      --key-file "/ssl/$(bashio::config 'keyfile')" \
+      --cert-file "/ssl/tailscale/fullchain.pem" \
+      --key-file "/ssl/tailscale/privkey.pem" \
       "$(bashio::info.hostname).$(bashio::config 'domain_alias')"
   fi
 }

--- a/tailscale/rootfs/etc/services.d/cert/run
+++ b/tailscale/rootfs/etc/services.d/cert/run
@@ -4,10 +4,9 @@
 # Runs tailscale cert periodically
 # ==============================================================================
 
-# Request TLS certificate if configured
+# Request TLS certificate if domain_alias is set
 tailscale_cert() {
-  if bashio::config.true 'request_cert'; then
-    bashio::config.require 'domain_alias'
+  if bashio::config.has_value 'domain_alias'; then
     /opt/tailscale cert \
       --cert-file "/ssl/$(bashio::config 'certfile')" \
       --key-file "/ssl/$(bashio::config 'keyfile')" \
@@ -15,7 +14,7 @@ tailscale_cert() {
   fi
 }
 
-cert_err='Error running `tailscale cert`. Visit https://tailscale.com/kb/1153/enabling-https/ to setup HTTPS.'
+cert_err='Error running "tailscale cert". Visit https://tailscale.com/kb/1153/enabling-https/ to setup HTTPS.'
 
 if ! tailscale_cert; then
   bashio::exit.nok "$cert_err"

--- a/tailscale/rootfs/etc/services.d/cert/run
+++ b/tailscale/rootfs/etc/services.d/cert/run
@@ -1,0 +1,31 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Home Assistant Community Add-on: Tailscale
+# Runs tailscale cert periodically
+# ==============================================================================
+
+# Request TLS certificate if configured
+tailscale_cert() {
+  if bashio::config.true 'request_cert'; then
+    bashio::config.require 'domain_alias'
+    /opt/tailscale cert \
+      --cert-file "/ssl/$(bashio::config 'certfile')" \
+      --key-file "/ssl/$(bashio::config 'keyfile')" \
+      "$(bashio::info.hostname).$(bashio::config 'domain_alias')"
+  fi
+}
+
+cert_err='Error running `tailscale cert`. Visit https://tailscale.com/kb/1153/enabling-https/ to setup HTTPS.'
+
+if ! tailscale_cert; then
+  bashio::exit.nok "$cert_err"
+fi
+
+bashio::log.info 'Starting Tailscale TLS certificate fetcher...'
+
+while true; do
+  if ! tailscale_cert; then
+    bashio::log.error "$cert_err"
+  fi
+  sleep 86400 # Fetch certs once a day
+done


### PR DESCRIPTION
# Proposed Changes

Request TLS certificate from tailscale. HTTPS must be enabled for the tailnet.
https://tailscale.com/kb/1153/enabling-https/

## Related Issues

https://github.com/hassio-addons/addon-tailscale/issues/62

@lmagyar has an even easier solution in #137.