### PR TITLE
Add an option for accepting DNS.  Fixes #74

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -13,7 +13,7 @@ RUN \
         ipcalc=1.0.1-r0 \
         iproute2=5.17.0-r0 \
         iptables=1.8.8-r1 \
-        nginx=1.22.0-r0 \
+        nginx=1.22.0-r1 \
     \
     && ln -sf /sbin/xtables-nft-multi /sbin/ip6tables \
     && ln -sf /sbin/xtables-nft-multi /sbin/iptables \

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -25,3 +25,7 @@ devices:
 host_network: true
 schema:
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
+  accept_dns: bool
+options:
+  accept_dns: true
+  tags: []

--- a/tailscale/rootfs/etc/services.d/tailscaled/post
+++ b/tailscale/rootfs/etc/services.d/tailscaled/post
@@ -7,6 +7,7 @@ declare -a addresses
 declare -a routes
 declare ipinfo
 declare tags
+declare accept_dns
 
 # Find addresses from which we can extract routes can be advertised
 addresses+=($(bashio::network.ipv4_address || true))
@@ -37,6 +38,8 @@ done
 # Get configured tags
 tags=$(bashio::config "tags | join(\",\")" "")
 
+accept_dns=$(bashio::config "accept_dns" "true")
+
 # Wait for socket to be available
 while ! bashio::fs.socket_exists "/var/run/tailscale/tailscaled.sock";
 do
@@ -54,6 +57,7 @@ do
       --hostname "$(bashio::info.hostname)" \
       --advertise-exit-node \
       --accept-routes \
+      --accept-dns="${accept_dns}" \
       --advertise-routes="${routes[*]}" \
       --advertise-tags="${tags}"
 


### PR DESCRIPTION
# Proposed Changes

Add an option to allow tailscale not to accept DNS, allowing the HomeAssistant node to be used as a DNS server.

## Related Issues

#74 
