### PR TITLE
Add support for additional interfaces

### DIFF
--- a/tailscale/rootfs/etc/services.d/tailscaled/post
+++ b/tailscale/rootfs/etc/services.d/tailscaled/post
@@ -3,14 +3,18 @@
 # Home Assistant Community Add-on: Tailscale
 # Runs after the machine has been logged in into the Tailscale network
 # ==============================================================================
+declare -a interfaces
 declare -a addresses
 declare -a routes
 declare ipinfo
 declare tags
 
-# Find addresses from which we can extract routes can be advertised
-addresses+=($(bashio::network.ipv4_address || true))
-addresses+=($(bashio::network.ipv6_address || true))
+# Find interfaces and matching addresses from which we can extract routes to be advertised
+interfaces+=($(bashio::network.interfaces))
+for interface in "${interfaces[@]}"; do
+    addresses+=($(bashio::network.ipv4_address "${interface}"))
+    addresses+=($(bashio::network.ipv6_address "${interface}"))
+done
 routes=()
 
 for address in "${addresses[@]}"; do


### PR DESCRIPTION
# Proposed Changes

Get interfaces and related ip addresses instead of using main interface only.
[Coding reused](https://github.com/hassio-addons/addon-adguard-home/blob/8a5af900ca46ff480c174882361a03f3fa2517e1/adguard/rootfs/etc/cont-init.d/adguard.sh#L52-L56) from AdGuardHome add-on.

## Related Issues

#96 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
