### PR TITLE
Upgrade tailscale to 1.32.3 to address CVE-2022-41925

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://pkgs.tailscale.com/stable/tailscale_1.32.2_${ARCH}.tgz" \
+        "https://pkgs.tailscale.com/stable/tailscale_1.32.3_${ARCH}.tgz" \
         | tar zxvf - -C /opt/ --strip-components 1 \
     \
     && rm -f -r \

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://pkgs.tailscale.com/stable/tailscale_1.32.3_${ARCH}.tgz" \
+        "https://pkgs.tailscale.com/stable/tailscale_1.34.1_${ARCH}.tgz" \
         | tar zxvf - -C /opt/ --strip-components 1 \
     \
     && rm -f -r \

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://pkgs.tailscale.com/stable/tailscale_1.30.1_${ARCH}.tgz" \
+        "https://pkgs.tailscale.com/stable/tailscale_1.32.2_${ARCH}.tgz" \
         | tar zxvf - -C /opt/ --strip-components 1 \
     \
     && rm -f -r \


### PR DESCRIPTION
Hello, thank you for the work on the addon for tailscale! 😄

# Proposed Changes

> This change upgrades tailscale to [1.32.2](https://github.com/tailscale/tailscale/releases/tag/v1.32.2)

## Related Issues

> https://github.com/hassio-addons/addon-tailscale/pull/108 (Upgrade Tailscale to 1.30.1)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
