### PR TITLE
bump Tailscale version: 1.34.1

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://pkgs.tailscale.com/stable/tailscale_1.30.1_${ARCH}.tgz" \
+        "https://pkgs.tailscale.com/stable/tailscale_1.34.1_${ARCH}.tgz" \
         | tar zxvf - -C /opt/ --strip-components 1 \
     \
     && rm -f -r \

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -13,7 +13,7 @@ RUN \
         ipcalc=1.0.1-r0 \
         iproute2=5.17.0-r0 \
         iptables=1.8.8-r1 \
-        nginx=1.22.0-r1 \
+        nginx=1.22.1-r0 \
     \
     && ln -sf /sbin/xtables-nft-multi /sbin/ip6tables \
     && ln -sf /sbin/xtables-nft-multi /sbin/iptables \


### PR DESCRIPTION
# Proposed Changes

bump Tailscale to 1.34.1
bump nginx to 1.22.1-r0

The nginx bump was needed as pinned in the Dockerfile is not found on the repos anymore [Failed Build](https://github.com/hassio-addons/addon-tailscale/actions/runs/3715885676/jobs/6301583363)

Fixes: https://github.com/hassio-addons/addon-tailscale/issues/124