### PR TITLE
Suppress tailscaled logs after 200 lines

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -55,6 +55,7 @@ subnet to Tailscale.
 tags:
   - tag:example
   - tag:homeassistant
+log_level: info
 ```
 
 ### Option: `tags`
@@ -63,6 +64,28 @@ This option allows you to specify specific ACL tags for this Tailscale
 instance. They need to start with `tag:`.
 
 More information: <https://tailscale.com/kb/1068/acl-tags/>
+
+### Option: `log_level`
+
+Optionally enable tailscaled debug messages in the add-on's log. Turn it on only
+in case you are troubleshooting, because Tailscale's daemon is quite chatty.
+
+The `log_level` option controls the level of log output by the addon and can
+be changed to be more or less verbose, which might be useful when you are
+dealing with an unknown issue. Possible values are:
+
+- `trace`: Show every detail, like all called internal functions.
+- `debug`: Shows detailed debug information.
+- `info`: Normal (usually) interesting events.
+- `notice`: Normal but significant events.
+- `warning`: Exceptional occurrences that are not errors.
+- `error`: Runtime errors that do not require immediate action.
+- `fatal`: Something went terribly wrong. Add-on becomes unusable.
+
+Please note that each level automatically includes log messages from a
+more severe level, e.g., `debug` also shows `info` messages. By default,
+the `log_level` is set to `info`, which is the recommended setting unless
+you are troubleshooting.
 
 ## Changelog & Releases
 

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -15,6 +15,7 @@ RUN \
         iproute2=6.0.0-r1 \
         iptables=1.8.8-r2 \
         nginx=1.22.1-r0 \
+        coreutils=9.1-r0 \
     \
     && ln -sf /sbin/xtables-nft-multi /sbin/ip6tables \
     && ln -sf /sbin/xtables-nft-multi /sbin/iptables \

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -25,3 +25,4 @@ devices:
 host_network: true
 schema:
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
+  log_level: list(trace|debug|info|notice|warning|error|fatal)?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -9,7 +9,7 @@ declare -a options
 bashio::log.info 'Starting Tailscale...'
 
 options+=(--state=/data/tailscaled.state)
-# Opt out of client log upload
+# Opt out of client log upload to log.tailscale.io
 options+=(--no-logs-no-support)
 options+=(--tun=userspace-networking)
 
@@ -18,7 +18,9 @@ options+=(--tun=userspace-networking)
 
 # Run Tailscale
 if bashio::debug ; then
-    exec /opt/tailscaled "${options[@]}"
+  exec /opt/tailscaled "${options[@]}"
 else
-    exec /opt/tailscaled "${options[@]}" &> /dev/null
+  bashio::log.notice "Tailscale logs will be suppressed after 200 lines, set add-on's configuration option 'log_level' to 'debug' to see further logs"
+  set -o pipefail
+  /opt/tailscaled "${options[@]}" 2>&1 | stdbuf -i0 -oL -eL sed -n -e '1,200p' -e "201c[further tailscaled logs suppressed, set add-on's configuration option 'log_level' to 'debug' to see further tailscaled logs]" 
 fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -21,6 +21,5 @@ if bashio::debug ; then
   exec /opt/tailscaled "${options[@]}"
 else
   bashio::log.notice "Tailscale logs will be suppressed after 200 lines, set add-on's configuration option 'log_level' to 'debug' to see further logs"
-  set -o pipefail
   /opt/tailscaled "${options[@]}" 2>&1 | stdbuf -i0 -oL -eL sed -n -e '1,200p' -e "201c[further tailscaled logs suppressed, set add-on's configuration option 'log_level' to 'debug' to see further tailscaled logs]" 
 fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -9,10 +9,16 @@ declare -a options
 bashio::log.info 'Starting Tailscale...'
 
 options+=(--state=/data/tailscaled.state)
+# Opt out of client log upload
+options+=(--no-logs-no-support)
 options+=(--tun=userspace-networking)
 
 # Trigger post process to run, after stuff got connected
 ./post &
 
 # Run Tailscale
-exec /opt/tailscaled "${options[@]}"
+if bashio::debug ; then
+    exec /opt/tailscaled "${options[@]}"
+else
+    exec /opt/tailscaled "${options[@]}" &> /dev/null
+fi


### PR DESCRIPTION
# Proposed Changes

Tailscaled is quite chatty and emits a really large amount of log messages.

This PR disables these messages after 200 lines, but makes it possible to re-enable the full logging for troubleshooting.

Based on the idea from https://github.com/tailscale/tailscale-synology/pull/110

## Related Issues

--