### PR TITLE
Updating Tailscale to 1.36.0

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then ARCH="386"; fi \
     \
     && curl -L -s \
-        "https://pkgs.tailscale.com/stable/tailscale_1.30.1_${ARCH}.tgz" \
+        "https://pkgs.tailscale.com/stable/tailscale_1.36.0_${ARCH}.tgz" \
         | tar zxvf - -C /opt/ --strip-components 1 \
     \
     && rm -f -r \


### PR DESCRIPTION
# Proposed Changes

- Updating to version 1.36.0: https://github.com/tailscale/tailscale/releases/tag/v1.36.0

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
