### PR TITLE
Bugfix in migrated S6 scripts

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -1,4 +1,5 @@
 #!/command/with-contenv bashio
+# shellcheck shell=bash
 # ==============================================================================
 # Home Assistant Community Add-on: Tailscale
 # Runs the Nginx daemon

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -11,8 +11,5 @@ bashio::log.info 'Starting Tailscale...'
 options+=(--state=/data/tailscaled.state)
 options+=(--tun=userspace-networking)
 
-# Trigger post process to run, after stuff got connected
-./post &
-
 # Run Tailscale
 exec /opt/tailscaled "${options[@]}"


### PR DESCRIPTION
# Proposed Changes

Bugfix.

Line:
```
./post &
```

Causing error:
```
./run: line 19: ./post: No such file or directory
```

This script already got a standalone, oneshot "post-tailscaled" service.

## Related Issues

-