### PR TITLE
Revert "🗑️  Move away from Codenotary (#162)"

### DIFF
--- a/tailscale/build.yaml
+++ b/tailscale/build.yaml
@@ -5,3 +5,6 @@ build_from:
   armhf: ghcr.io/hassio-addons/base/armhf:13.2.0
   armv7: ghcr.io/hassio-addons/base/armv7:13.2.0
   i386: ghcr.io/hassio-addons/base/i386:13.2.0
+codenotary:
+  base_image: codenotary@frenck.dev
+  signer: codenotary@frenck.dev

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -4,6 +4,7 @@ version: dev
 slug: tailscale
 description: Zero config VPN for building secure networks
 url: https://github.com/hassio-addons/addon-tailscale
+codenotary: codenotary@frenck.dev
 ingress: true
 ingress_port: 0
 ingress_stream: true


### PR DESCRIPTION

# Proposed Changes

This reverts commit fa78fb76f07e93af143b42838054e4c66d997626.

We can't move away just yet, as the Supervisor currently prevents this.