### PR TITLE
Enable Tailscale's builtin outbound SOCKS5 and HTTP proxy

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -54,6 +54,11 @@ subnets on all supported interfaces to Tailscale.
 Consider disabling key expiry to avoid losing connection to your Home Assistant
 device. See [Key expiry][tailscale_info_key_expiry] for more information.
 
+To allow Home Assistant and other add-ons to access your Tailscale network the
+add-on also provides a SOCKS5/HTTP proxy. The proxy protocol is unauthenticated.
+See [Userspace networking][tailscale_info_userspace_networking] for more
+information.
+
 ```yaml
 tags:
   - tag:example
@@ -67,16 +72,6 @@ This option allows you to specify specific ACL tags for this Tailscale
 instance. They need to start with `tag:`.
 
 More information: <https://tailscale.com/kb/1068/acl-tags/>
-
-### Option: `proxy_port`
-
-Optionally select a port on localhost (`127.0.0.1`) to listen on for connections
-from SOCKS5 and HTTP proxy-speaking applications. Enabling this feature allows
-Home Assistant and other add-ons to access your Tailscale network.
-
-The proxy protocol is unauthenticated.
-
-More information: [Userspace networking][tailscale_info_userspace_networking]
 
 ### Option: `log_level`
 

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -68,6 +68,14 @@ instance. They need to start with `tag:`.
 
 More information: <https://tailscale.com/kb/1068/acl-tags/>
 
+### Option: `proxy_port`
+
+Optionally select a port on localhost (`127.0.0.1`) to listen on for connections
+from SOCKS5 and HTTP proxy-speaking applications. Enabling this feature allows
+Home Assistant and other add-ons to access your Tailscale network.
+
+The proxy protocol is unauthenticated.
+
 ### Option: `log_level`
 
 Optionally enable tailscaled debug messages in the add-on's log. Turn it on only

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -76,6 +76,8 @@ Home Assistant and other add-ons to access your Tailscale network.
 
 The proxy protocol is unauthenticated.
 
+More information: [Userspace networking][tailscale_info_userspace_networking]
+
 ### Option: `log_level`
 
 Optionally enable tailscaled debug messages in the add-on's log. Turn it on only
@@ -178,3 +180,4 @@ SOFTWARE.
 [semver]: https://semver.org/spec/v2.0.0.html
 [taildrop]: https://tailscale.com/taildrop/
 [tailscale_info_key_expiry]: https://tailscale.com/kb/1028/key-expiry/
+[tailscale_info_userspace_networking]: https://tailscale.com/kb/1112/userspace-networking/

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -23,4 +23,5 @@ map:
   - share:rw
 schema:
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
+  proxy_port: match(^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$)?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -21,7 +21,10 @@ hassio_api: true
 host_network: true
 map:
   - share:rw
+ports:
+  1080/tcp: 1080
+ports_description:
+  1080/tcp: SOCKS5 and HTTP proxy port for outbound connections into your Tailscale network (make empty to disable)
 schema:
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
-  proxy_port: match(^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$)?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -5,6 +5,7 @@
 # Runs tailscale
 # ==============================================================================
 declare -a options
+declare outbound_proxy_port
 
 bashio::log.info 'Starting Tailscale...'
 
@@ -13,9 +14,12 @@ options+=(--statedir=/data/state)
 # Opt out of client log upload to log.tailscale.io
 options+=(--no-logs-no-support)
 options+=(--tun=userspace-networking)
-if bashio::config.has_value "proxy_port"; then
-  options+=(--socks5-server=127.0.0.1:"$(bashio::config "proxy_port")")
-  options+=(--outbound-http-proxy-listen=127.0.0.1:"$(bashio::config "proxy_port")")
+
+# If outbound proxy port is specified, enable outbound proxy
+outbound_proxy_port=$(bashio::addon.port 1080)
+if bashio::var.has_value "${outbound_proxy_port}"; then
+  options+=(--socks5-server=0.0.0.0:${outbound_proxy_port})
+  options+=(--outbound-http-proxy-listen=0.0.0.0:${outbound_proxy_port})
 fi
 
 # Run Tailscale

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -13,6 +13,10 @@ options+=(--statedir=/data/state)
 # Opt out of client log upload to log.tailscale.io
 options+=(--no-logs-no-support)
 options+=(--tun=userspace-networking)
+if bashio::config.has_value "proxy_port"; then
+  options+=(--socks5-server=127.0.0.1:"$(bashio::config "proxy_port")")
+  options+=(--outbound-http-proxy-listen=127.0.0.1:"$(bashio::config "proxy_port")")
+fi
 
 # Run Tailscale
 if bashio::debug ; then


### PR DESCRIPTION
# Proposed Changes

Tailscale runs in userspace-networking mode, accessing nodes in the Tailscale VPN from HA or other containers is not possible.

Though Tailscale provides SOCKS5 and HTTP proxy exactly for this situation (https://tailscale.com/kb/1112/userspace-networking/)

This PR optionally enables this functionality for those who want to access nodes on their Tailscale VPN.

## Related Issues

#169 #129 #67

Fixes: #169
