### PR TITLE
Remove unneeded add-on privileges

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -18,10 +18,6 @@ arch:
   - i386
 init: false
 hassio_api: true
-privileged:
-  - NET_ADMIN
-devices:
-  - /dev/net/tun
 host_network: true
 map:
   - share:rw


### PR DESCRIPTION
# Proposed Changes

In PR #41 tailscaled moved on to userspace-networking, though the add-on privileges required for tun remained in the config.yaml. 

## Related Issues
