### PR TITLE
Allow customizing the login server

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -90,6 +90,11 @@ more severe level, e.g., `debug` also shows `info` messages. By default,
 the `log_level` is set to `info`, which is the recommended setting unless
 you are troubleshooting.
 
+### Option: `login_server`
+
+This option allows you to specify an alternative login server instead of the default `https://controlplane.tailscale.com`.
+You can for example specify a selfhosted [headscale](https://github.com/juanfont/headscale) instance.
+
 ## Taildrop
 
 This add-on support [Tailscale's Taildrop][taildrop] feature, which allows

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -24,3 +24,6 @@ map:
 schema:
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  login_server: str
+options:
+  login_server: "https://controlplane.tailscale.com"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -47,6 +47,9 @@ readarray -t routes < <(printf "%s\n" "${routes[@]}" | sort -u)
 # Get configured tags
 tags=$(bashio::config "tags//[] | join(\",\")" "")
 
+# Get server to login against
+login_server=$(bashio::config 'login_server' 'https://controlplane.tailscale.com')
+
 # Wait for socket to be available
 while ! bashio::fs.socket_exists "/var/run/tailscale/tailscaled.sock";
 do
@@ -65,7 +68,8 @@ do
       --advertise-exit-node \
       --accept-routes \
       --advertise-routes="${routes[*]}" \
-      --advertise-tags="${tags}"
+      --advertise-tags="${tags}" \
+      --login-server="${login_server}"
 
     bashio::exit.ok
   fi


### PR DESCRIPTION
# Proposed Changes

This PR adds the option to specify another login server instead of the default tailscale server.
This allows to specify for example an selfhosted [headscale](https://github.com/juanfont/headscale) instance as an alternative.

## Related Issues

https://github.com/hassio-addons/addon-tailscale/issues/90
https://github.com/hassio-addons/addon-tailscale/issues/144

