### PR TITLE
Add custom control server support

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -59,14 +59,8 @@ tags:
   - tag:example
   - tag:homeassistant
 log_level: info
+login_server: "https://controlplane.tailscale.com"
 ```
-
-### Option: `tags`
-
-This option allows you to specify specific ACL tags for this Tailscale
-instance. They need to start with `tag:`.
-
-More information: <https://tailscale.com/kb/1068/acl-tags/>
 
 ### Option: `log_level`
 
@@ -89,6 +83,20 @@ Please note that each level automatically includes log messages from a
 more severe level, e.g., `debug` also shows `info` messages. By default,
 the `log_level` is set to `info`, which is the recommended setting unless
 you are troubleshooting.
+
+### Option: `login_server`
+
+This option lets you specify you to specify a custom control server instead of
+the default (`https://controlplane.tailscale.com`). This is useful if you
+are running your own Tailscale control server, for example, a self-hosted
+[Headscale] instance.
+
+### Option: `tags`
+
+This option allows you to specify specific ACL tags for this Tailscale
+instance. They need to start with `tag:`.
+
+More information: <https://tailscale.com/kb/1068/acl-tags/>
 
 ## Taildrop
 
@@ -164,6 +172,7 @@ SOFTWARE.
 [discord]: https://discord.me/hassioaddons
 [forum]: https://community.home-assistant.io/?u=frenck
 [frenck]: https://github.com/frenck
+[headscale]: https://github.com/juanfont/headscale
 [issue]: https://github.com/hassio-addons/addon-tailscale/issues
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/addon-tailscale/releases

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -22,5 +22,6 @@ host_network: true
 map:
   - share:rw
 schema:
-  tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  login_server: url?
+  tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -5,14 +5,32 @@
 # Runs after the machine has been logged in into the Tailscale network
 # ==============================================================================
 declare -a addresses=()
+declare -a options
 declare -a routes=()
 declare ipinfo
+declare login_server
 declare tags
 
 function appendarray() {
   local -n array=${1}
   readarray -t -O "${#array[@]}" array
 }
+
+# Default options
+options+=(--accept-routes)
+options+=(--advertise-exit-node)
+options+=(--hostname "$(bashio::info.hostname)")
+
+# Get configured control server
+if bashio::config.has_value "login_server";
+then
+  tags=$(bashio::config "login_server")
+  options+=(--login_server="${login_server}")
+fi
+
+# Get configured tags
+tags=$(bashio::config "tags//[] | join(\",\")" "")
+options+=(--advertise-tags="${tags}")
 
 # Find interfaces and matching addresses from which we can extract routes to be advertised
 for interface in $(bashio::network.interfaces); do
@@ -41,34 +59,20 @@ for address in "${addresses[@]}"; do
     routes+=("$(bashio::jq "${ipinfo}" '.NETWORK + "/" + .PREFIX')")
   fi
 done
+
 # Remove duplicate entries
 readarray -t routes < <(printf "%s\n" "${routes[@]}" | sort -u)
 
-# Get configured tags
-tags=$(bashio::config "tags//[] | join(\",\")" "")
-
-# Wait for socket to be available
-while ! bashio::fs.socket_exists "/var/run/tailscale/tailscaled.sock";
-do
-  sleep 1
-done
+IFS=","
+options+=(--advertise-routes="${routes[*]}")
+unset IFS
 
 # Wait for the network to be available and logged in
-while true;
-do
-  if /opt/tailscale status --json --peers=false --self=false \
+while ! bashio::fs.socket_exists "/var/run/tailscale/tailscaled.sock" || \
+  ! /opt/tailscale status --json --peers=false --self=false \
     | jq --exit-status '.BackendState == "Running" or .BackendState == "NeedsLogin"' > /dev/null;
-  then
-    IFS=","
-    /opt/tailscale up \
-      --hostname "$(bashio::info.hostname)" \
-      --advertise-exit-node \
-      --accept-routes \
-      --advertise-routes="${routes[*]}" \
-      --advertise-tags="${tags}"
-
-    bashio::exit.ok
-  fi
-  # Well... wait a bit more
+do
   sleep 2
 done
+
+/opt/tailscale up "${options[@]}"

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -5,6 +5,12 @@ configuration:
     description: >-
       Controls the level of log details the add-on provides.
       This only applies to the add-on itself, not Tailscale.
+  login_server:
+    name: Login server
+    description: >-
+      This option allows you to specify a custom control server for this
+      Tailscale instance, for example, a self-host Headscale instance.
+      By default, it uses the control server provided by Tailscale.
   tags:
     name: Tags
     description: >-


### PR DESCRIPTION
# Proposed Changes

Adds support for setting a custom control server (e.g., a self-hosted Headscale instance).

supersedes and closes #175
