### PR TITLE
Fix typo "login_server: unbound variable"

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -24,7 +24,7 @@ options+=(--hostname "$(bashio::info.hostname)")
 # Get configured control server
 if bashio::config.has_value "login_server";
 then
-  tags=$(bashio::config "login_server")
+  login_server=$(bashio::config "login_server")
   options+=(--login_server="${login_server}")
 fi
 


### PR DESCRIPTION
# Proposed Changes

Fix typo when adding a custom login_server.

```
/etc/s6-overlay/s6-rc.d/post-tailscaled/run: line 28: login_server: unbound variable
```

## Related Issues

#180 
