### PR TITLE
Fix login-server option

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -25,7 +25,7 @@ options+=(--hostname "$(bashio::info.hostname)")
 if bashio::config.has_value "login_server";
 then
   login_server=$(bashio::config "login_server")
-  options+=(--login_server="${login_server}")
+  options+=(--login-server="${login_server}")
 fi
 
 # Get configured tags


### PR DESCRIPTION
# Proposed Changes

It should have been `login-server` instead of `login_server`.

Tested this and works fine now.
