### PR TITLE
Add taildrop to example configuration

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -56,11 +56,12 @@ device. See [Key expiry][tailscale_info_key_expiry] for more information.
 
 ```yaml
 advertise_exit_node: true
+log_level: info
+login_server: "https://controlplane.tailscale.com"
 tags:
   - tag:example
   - tag:homeassistant
-log_level: info
-login_server: "https://controlplane.tailscale.com"
+taildrop: true
 ```
 
 ### Option: `advertise_exit_node`


### PR DESCRIPTION
# Proposed Changes

PR #185 didn't add taildrop to the example config in the DOCS.

Also PR #180 moved the tags config to the end in the description, but not in the example config.

## Related Issues

