### PR TITLE
Make accepting magicDNS optional

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -22,6 +22,7 @@ host_network: true
 map:
   - share:rw
 schema:
+  accept_dns: bool?
   advertise_exit_node: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -20,6 +20,15 @@ function appendarray() {
 options+=(--accept-routes)
 options+=(--hostname "$(bashio::info.hostname)")
 
+# Accept magicDNS by default when not set, or when explicitly enabled
+if ! bashio::config.has_value "accept_dns" || \
+  bashio::config.true "accept_dns";
+then
+  options+=(--accept-dns)
+else
+  options+=(--accept-dns=false)
+fi
+
 # Advertise as exit node by default when not set, or when explicitly enabled
 if ! bashio::config.has_value "advertise_exit_node" || \
   bashio::config.true "advertise_exit_node";

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -1,5 +1,11 @@
 ---
 configuration:
+  accept_dns:
+    name: Accept DNS
+    description: >-
+      If you are experiencing trouble with MagicDNS on this device and wish to
+      disable, you can do so using this option.
+      When not set, this option is enabled by default.
   advertise_exit_node:
     name: Advertise as an exit node
     description: >-


### PR DESCRIPTION
# Proposed Changes

Adds the option to disable accepting MagicDNS. This might be helpful/needed when the user runs things like Pi-hole/AdGuard on the same machine.

A user can still use MagicDNS in such cases, by pointing their DNS server to `100.100.100.100` (and `fd7a:115c:a1e0::53`).

