### PR TITLE
Remove duplicate status checks from dependent S6 services

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -92,4 +92,17 @@ do
   sleep 2
 done
 
-/opt/tailscale up "${options[@]}"
+# Start Tailscale
+if ! /opt/tailscale up "${options[@]}"; then
+  bashio::log.error "Unable to start up Tailscale"
+  bashio::exit.nok
+fi
+
+# Wait for the network to be available and logged in
+while ! /opt/tailscale status --json --peers=false --self=false \
+  | jq --exit-status '.BackendState == "Running"' > /dev/null
+do
+  sleep 2
+done
+
+bashio::log.info "Tailscale is running"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/proxy/run
@@ -7,14 +7,6 @@
 
 declare domain
 
-# Wait for the network to be available and logged in
-while ! bashio::fs.socket_exists "/var/run/tailscale/tailscaled.sock" || \
-  ! /opt/tailscale status --json --peers=false --self=false \
-    | jq --exit-status '.BackendState == "Running"' > /dev/null
-do
-  sleep 2
-done
-
 # Check if Tailscale HTTPS is enabled
 if ! /opt/tailscale status --self=true --peers=false --json \
   | jq -rce ".CertDomains[0]" > /dev/null;

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/taildrop/run
@@ -5,14 +5,6 @@
 # Fetches files send via Taildrop
 # ==============================================================================
 
-# Wait for the network to be available and logged in
-while ! bashio::fs.socket_exists "/var/run/tailscale/tailscaled.sock" || \
-  ! /opt/tailscale status --json --peers=false --self=false \
-    | jq --exit-status '.BackendState == "Running"' > /dev/null
-do
-  sleep 2
-done
-
 # Ensure the directory exists
 mkdir -p /share/taildrop
 


### PR DESCRIPTION
# Proposed Changes

Minor code quality improvement.

The `proxy` and `taildrop` services are waiting for `post-tailscaled`, so move the status checks from the beginning of `proxy` and `taildrop` to the end of `post-tailscaled`.

## Related Issues
