### PR TITLE
Create fallback page for iOS browsers failing to open Tailscale login page

### DIFF
--- a/tailscale/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/tailscale/rootfs/etc/nginx/templates/ingress.gtpl
@@ -11,7 +11,7 @@ server {
         proxy_pass http://backend;
 
         sub_filter_once off;
-        sub_filter 'document.location.href = url' 'var result = window.open(url, "_blank"); if (result!== null) {result.focus()} else {document.write(\'<font color=white>Unable to open Tailscale in new window.  Please copy this URL; open in a separate browser; and re-load the addon Web UI here when complete.   <a href="\' + url + \'">\'+url+\'</a></font>\')}';
+        sub_filter 'document.location.href = url' 'var result = window.open(url, "_blank"); if (result!== null) {result.focus()} else {document.write(\'<div style="background-color:white"><font color=black>Unable to open Tailscale in new window.  Please copy this URL; open in a separate browser; and re-load the addon Web UI here when complete.   <a href="\' + url + \'">\'+url+\'</a></font></div>\')}';
 
     }
 }

--- a/tailscale/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/tailscale/rootfs/etc/nginx/templates/ingress.gtpl
@@ -11,6 +11,7 @@ server {
         proxy_pass http://backend;
 
         sub_filter_once off;
-        sub_filter 'document.location.href = url' 'window.open(url, "_blank").focus()';
+        sub_filter 'document.location.href = url' 'var result = window.open(url, "_blank"); if (result!== null) {result.focus()} else {document.write(\'<font color=white>Unable to open Tailscale in new window.  Please copy this URL; open in a separate browser; and re-load the addon Web UI here when complete.   <a href="\' + url + \'">\'+url+\'</a></font>\')}';
+
     }
 }

--- a/tailscale/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/tailscale/rootfs/etc/nginx/templates/ingress.gtpl
@@ -11,7 +11,7 @@ server {
         proxy_pass http://backend;
 
         sub_filter_once off;
-        sub_filter 'document.location.href = url' 'var result = window.open(url, "_blank"); if (result!== null) {result.focus()} else {document.write(\'<div style="background-color:white"><font color=black>Unable to open Tailscale in new window.  Please copy this URL; open in a separate browser; and re-load the addon Web UI here when complete.   <a href="\' + url + \'">\'+url+\'</a></font></div>\')}';
+        sub_filter 'document.location.href = url' 'var result = window.open(url, "_blank"); if (result!== null) {result.focus()} else {document.write(\'<div style="background-color:white"><font color=black>Unable to open Tailscale in new window.  Please copy this URL, open it in a separate browser, and re-load the addon Web UI here when complete.   <a href="\' + url + \'">\'+url+\'</a></font></div>\')}';
 
     }
 }


### PR DESCRIPTION
# Proposed Changes

Modify nginx ingress JS replacement for rendered tailscale link pages to provide fallback on mobile for target=_blank links. 

On iOS mobile, error page currently appears when clicking link to Tailscale.  
![image](https://user-images.githubusercontent.com/6220097/235396366-6e54e5be-6e50-4a6f-a6e0-b4ad29750842.png)

If link fails to open, falls back to displaying URL to be copy-pasted into browser.
![image](https://user-images.githubusercontent.com/6220097/235396410-cd72eb4e-186b-4314-bce7-0604b7484d9f.png)

## Related Issues

- fixes https://github.com/hassio-addons/addon-tailscale/issues/157
- fixes https://github.com/hassio-addons/addon-tailscale/issues/258
