### PR TITLE
Make userspace networking configurable

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -196,11 +196,11 @@ accessible within your tailnet.
 When not set, this option is enabled by default.
 
 If you need to access other clients on your tailnet from your Home Assistant
-instance, disable userspace networking mode, that will create a `tailscale0`
+instance, disable userspace networking mode, which will create a `tailscale0`
 network interface on your host.
 
 If you want to access other clients on your tailnet even from your local subnet,
-execute Step 2 and 3 as described on [Site-to-site
+execute steps 2 and 3 as described on [Site-to-site
 networking][tailscale_info_site_to_site].
 
 ### Option: `proxy`

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -70,6 +70,7 @@ tags:
   - tag:example
   - tag:homeassistant
 taildrop: true
+userspace_networking: true
 ```
 
 ### Option: `accept_dns`
@@ -185,6 +186,22 @@ This option lets you specify you to specify a custom control server instead of
 the default (`https://controlplane.tailscale.com`). This is useful if you
 are running your own Tailscale control server, for example, a self-hosted
 [Headscale] instance.
+
+### Option: `userspace_networking`
+
+The add-on uses [userspace networking mode][tailscale_info_userspace_networking]
+to make your Home Assistant instance (and optionally the local subnets)
+accessible within your tailnet.
+
+When not set, this option is enabled by default.
+
+If you need to access other clients on your tailnet from your Home Assistant
+instance, disable userspace networking mode, that will create a `tailscale0`
+network interface on your host.
+
+If you want to access other clients on your tailnet even from your local subnet,
+execute Step 2 and 3 as described on [Site-to-site
+networking][tailscale_info_site_to_site].
 
 ### Option: `proxy`
 
@@ -325,3 +342,5 @@ SOFTWARE.
 [tailscale_info_funnel]: https://tailscale.com/kb/1223/tailscale-funnel/
 [tailscale_info_https]: https://tailscale.com/kb/1153/enabling-https/
 [tailscale_info_key_expiry]: https://tailscale.com/kb/1028/key-expiry/
+[tailscale_info_site_to_site]: https://tailscale.com/kb/1214/site-to-site/
+[tailscale_info_userspace_networking]: https://tailscale.com/kb/1112/userspace-networking/

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -36,3 +36,4 @@ schema:
   proxy: bool?
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
   taildrop: bool?
+  userspace_networking: bool?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -122,3 +122,13 @@ if keyexpiry=$(/opt/tailscale status --self=true --peers=false --json | jq -rce 
 fi
 
 bashio::log.info "Tailscale is running"
+
+# Warn about userspace networking
+if ! bashio::config.has_value "userspace_networking" || \
+    bashio::config.true "userspace_networking";
+then
+  bashio::log.notice "The add-on uses userspace networking mode."
+  bashio::log.notice "If you need to access other clients on your tailnet from your Home Assistant instance,"
+  bashio::log.notice "disable userspace networking mode, that will create a \"tailscale0\" network interface on your host."
+  bashio::log.notice "Please check your configuration based on the add-on's Documentation under \"Option: userspace_networking\""
+fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -16,6 +16,13 @@ if ! bashio::debug ; then
   options+=(--no-logs-no-support)
 fi
 
+# Use userspace networking by default when not set, or when explicitly enabled
+if ! bashio::config.has_value "userspace_networking" || \
+  bashio::config.true "userspace_networking";
+then
+  options+=(--tun=userspace-networking)
+fi
+
 # Run Tailscale
 if bashio::debug ; then
   exec /opt/tailscaled "${options[@]}"

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -54,3 +54,11 @@ configuration:
       This option allows you to enable Taildrop, a file sharing service
       that allows you to share files with other Tailscale nodes.
       When not set, this option is enabled by default.
+  userspace_networking:
+    name: Userspace networking mode
+    description: >-
+      This option allows you to enable userspace networking mode.
+      If you need to access other clients on your Tailnet from your Home
+      Assistant instance, disable userspace networking mode, that will create a
+      `tailscale0` network interface on your host.
+      When not set, this option is enabled by default.

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -59,6 +59,6 @@ configuration:
     description: >-
       This option allows you to enable userspace networking mode.
       If you need to access other clients on your Tailnet from your Home
-      Assistant instance, disable userspace networking mode, that will create a
+      Assistant instance, disable userspace networking mode, which will create a
       `tailscale0` network interface on your host.
       When not set, this option is enabled by default.


### PR DESCRIPTION
Note: this is based on / continuation of #196, but I will rebase this PR as required.

# Proposed Changes

The currently unreleased #181 dropped userspace networking automatically.

I've merged it into my fork, and 1 user complained, that his host lost all network access (even local 192.168.x.x did not worked). ***UPDATE:*** _The reason must be that the same subnet is advertised at multiple locations and it caused collision. The PR #201 provides a possible solution for collision, but I think making userspace-networking configurable still makes sense._

This PR makes it configurable, by default the add-on still uses userspace networking, but if somebody adds `userspace_networking: false` to the configuration, it will drop it and create the `tailscale0` interface with all of the dangers of it. 

But at least it requires manual intervention and doesn't happen automatically during an add-on update.

## Related Issues
