### PR TITLE
Do not opt out of client log upload in debug log level

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -92,7 +92,9 @@ When not set, this option is enabled by default.
 ### Option: `log_level`
 
 Optionally enable tailscaled debug messages in the add-on's log. Turn it on only
-in case you are troubleshooting, because Tailscale's daemon is quite chatty.
+in case you are troubleshooting, because Tailscale's daemon is quite chatty. If
+`log_level` is set to `info` or less severe level, the add-on also opts out of
+client log upload to log.tailscale.io.
 
 The `log_level` option controls the level of log output by the addon and can
 be changed to be more or less verbose, which might be useful when you are

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -12,7 +12,9 @@ options+=(--state=/data/tailscaled.state)
 options+=(--statedir=/data/state)
 
 # Opt out of client log upload to log.tailscale.io
-options+=(--no-logs-no-support)
+if ! bashio::debug ; then
+  options+=(--no-logs-no-support)
+fi
 
 # Run Tailscale
 if bashio::debug ; then


### PR DESCRIPTION
# Proposed Changes

Don't use `--no-logs-no-support` option when the add-on's log level is debug, to prevent _"Failed Operation: backend error: tailnet requires logging to be enabled. Remove --no-logs-no-support from tailscaled command line."_ errors when users enable flow logging in their tailnet.

## Related Issues

fixes #211
