### PR TITLE
Make subnet source NAT configurable

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -275,7 +275,7 @@ port 443._
 ### Option: `snat_subnet_routes`
 
 This option allows subnet devices to see the traffic originating from the subnet
-router, and this simplifyies routing configuration.
+router, and this simplifies routing configuration.
 
 When not set, this option is enabled by default.
 

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -69,6 +69,7 @@ advertise_routes:
 log_level: info
 login_server: "https://controlplane.tailscale.com"
 proxy: true
+snat_subnet_routes: true
 tags:
   - tag:example
   - tag:homeassistant
@@ -270,6 +271,17 @@ More information: [Enabling HTTPS][tailscale_info_https]
 **Note:** _You should not use any port number in the URL that you used
 previously to access Home Assistant. Tailscale Proxy works on the default HTTPS
 port 443._
+
+### Option: `snat_subnet_routes`
+
+This option allows subnet devices to see the traffic originating from the subnet
+router, and this simplifyies routing configuration.
+
+When not set, this option is enabled by default.
+
+To support advanced [Site-to-site networking][tailscale_info_site_to_site] (eg.
+to traverse multiple networks), you can disable this functionality. But do it
+only when you really understand why you need this.
 
 ### Option: `tags`
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -37,6 +37,7 @@ schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?
   proxy: bool?
+  snat_subnet_routes: bool?
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
   taildrop: bool?
   userspace_networking: bool?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -49,6 +49,15 @@ then
   options+=(--login-server="${login_server}")
 fi
 
+# Support advanced site-to-site networking, disable source addresses NAT
+if ! bashio::config.has_value "snat_subnet_routes" || \
+  bashio::config.true "snat_subnet_routes";
+then
+  options+=(--snat-subnet-routes)
+else
+  options+=(--snat-subnet-routes=false)
+fi
+
 # Get configured tags
 tags=$(bashio::config "tags//[] | join(\",\")" "")
 options+=(--advertise-tags="${tags}")

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -54,7 +54,7 @@ configuration:
     name: Source NAT subnet routes
     description: >-
       This option allows subnet devices to see the traffic originating from the
-      subnet router, and this simplifyies routing configuration.
+      subnet router, and this simplifies routing configuration.
       To support advanced Site-to-site networking (eg. to traverse multiple
       networks), you can disable this functionality.
       When not set, this option is enabled by default.

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -50,6 +50,14 @@ configuration:
       This option allows you to enable Tailscale's Proxy feature to present your
       Home Assistant instance on your tailnet with a valid certificate.
       When not set, this option is enabled by default.
+  snat_subnet_routes:
+    name: Source NAT subnet routes
+    description: >-
+      This option allows subnet devices to see the traffic originating from the
+      subnet router, and this simplifyies routing configuration.
+      To support advanced Site-to-site networking (eg. to traverse multiple
+      networks), you can disable this functionality.
+      When not set, this option is enabled by default.
   tags:
     name: Tags
     description: >-


### PR DESCRIPTION
# Proposed Changes

Makes possible to fully utilize site-to-site networking, allows to disable source NAT for subnet devices.

Source: https://tailscale.com/kb/1214/site-to-site/ Step 1 / Point 2

## Related Issues
