### PR TITLE
make accepting subnet routes optional

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -56,6 +56,7 @@ device. See [Key expiry][tailscale_info_key_expiry] for more information.
 
 ```yaml
 accept_dns: true
+accept_routes: true
 advertise_exit_node: true
 log_level: info
 login_server: "https://controlplane.tailscale.com"
@@ -77,6 +78,15 @@ MagicDNS may cause issues if you run things like Pi-hole or AdGuard Home
 on the same machine as this add-on. In such cases disabling `accept_dns`
 will help. You can still leverage MagicDNS on other devices on your network,
 by adding `100.100.100.100` as a DNS server in your Pi-hole or AdGuard Home.
+
+### Option: `accept_routes`
+
+This option allows you to accept subnet routes advertised by other nodes in
+your tailnet.
+
+More information: <https://tailscale.com/kb/1019/subnets/>
+
+When not set, this option is enabled by default.
 
 ### Option: `advertise_exit_node`
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -28,6 +28,7 @@ map:
   - share:rw
 schema:
   accept_dns: bool?
+  accept_routes: bool?
   advertise_exit_node: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -17,7 +17,6 @@ function appendarray() {
 }
 
 # Default options
-options+=(--accept-routes)
 options+=(--hostname "$(bashio::info.hostname)")
 
 # Accept magicDNS by default when not set, or when explicitly enabled
@@ -27,6 +26,15 @@ then
   options+=(--accept-dns)
 else
   options+=(--accept-dns=false)
+fi
+
+# Accept routes by default when not set, or when explicitly enabled
+if ! bashio::config.has_value "accept_routes" || \
+  bashio::config.true "accept_routes";
+then
+  options+=(--accept-routes)
+else
+  options+=(--accept-routes=false)
 fi
 
 # Advertise as exit node by default when not set, or when explicitly enabled

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -6,6 +6,12 @@ configuration:
       If you are experiencing trouble with MagicDNS on this device and wish to
       disable, you can do so using this option.
       When not set, this option is enabled by default.
+  accept_routes:
+    name: Accept Routes
+    description: >-
+      This option allows you to accept subnet routes advertised by other nodes
+      in your tailnet.
+      When not set, this option is enabled by default.
   advertise_exit_node:
     name: Advertise as an exit node
     description: >-


### PR DESCRIPTION
This is needed in some scenarios, such as when the other node is advertising the subnet that home assistant is on.