### PR TITLE
Make advertise routes configurable

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -63,6 +63,9 @@ accept_dns: true
 accept_routes: true
 advertise_exit_node: true
 funnel: true
+advertise_routes:
+  - 192.168.1.0/24
+  - fd12:3456:abcd::/64
 log_level: info
 login_server: "https://controlplane.tailscale.com"
 proxy: true
@@ -104,6 +107,22 @@ route all your public internet traffic as needed, like a consumer VPN.
 More information: <https://tailscale.com/kb/1103/exit-nodes/>
 
 When not set, this option is enabled by default.
+
+### Option: `advertise_routes`
+
+This option allows you to advertise routes to subnets (accessible on the network
+your device is connected to) to other clients on your tailnet.
+
+By adding to the list the IP addresses and masks of the subnet routes, you can
+use it to make your devices on these subnets accessible within your tailnet.
+
+If you want to disable this option, specify an empty list in the configuration
+(`[]` in YAML).
+
+More information: [Subnet routers][tailscale_info_subnets]
+
+When not set, the add-on by default will advertise routes to your subnets on all
+supported interfaces.
 
 ### Option: `funnel`
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -31,6 +31,8 @@ schema:
   accept_dns: bool?
   accept_routes: bool?
   advertise_exit_node: bool?
+  advertise_routes:
+    - "match(^(((25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\/(3[0-2]|[12]?\\d)|[a-fA-F\\d.:]+:[a-fA-F\\d.:]+\\/(12[0-8]|(1[01]|[1-9]?)\\d))$)?"
   funnel: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -53,7 +53,7 @@ fi
 tags=$(bashio::config "tags//[] | join(\",\")" "")
 options+=(--advertise-tags="${tags}")
 
-# Find interfaces and matching addresses and extract routes to be advertised
+# Advertise subnet routes
 readarray -t routes < <(subnet-routes)
 IFS=","
 options+=(--advertise-routes="${routes[*]}")

--- a/tailscale/rootfs/usr/bin/subnet-routes
+++ b/tailscale/rootfs/usr/bin/subnet-routes
@@ -5,6 +5,7 @@
 # ==============================================================================
 declare interface
 declare -a addresses=()
+declare address
 declare -a routes=()
 declare ipinfo
 declare response
@@ -18,11 +19,18 @@ if bashio::cache.exists 'subnet-routes'; then
   readarray -t routes < <(bashio::cache.get 'subnet-routes')
   printf -v response "%s" "${routes[@]/%/$'\n'}"
 else
-  # Find interfaces and matching addresses from which we can extract routes to be advertised
-  for interface in $(bashio::network.interfaces); do
-    appendarray addresses < <(bashio::network.ipv4_address "${interface}")
-    appendarray addresses < <(bashio::network.ipv6_address "${interface}")
-  done
+  if bashio::config.exists "advertise_routes"; then
+    # Configuration exists, use configured values
+    for address in $(bashio::config "advertise_routes"); do
+      addresses+=("${address}")
+    done
+  else
+    # Find interfaces and matching addresses from which we can extract routes to be advertised
+    for interface in $(bashio::network.interfaces); do
+      appendarray addresses < <(bashio::network.ipv4_address "${interface}")
+      appendarray addresses < <(bashio::network.ipv6_address "${interface}")
+    done
+  fi
 
   # Extract routes to be advertised
   for address in "${addresses[@]}"; do

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -19,6 +19,13 @@ configuration:
       By setting a device on your network as an exit node, you can use it to
       route all your public internet traffic as needed, like a consumer VPN.
       When not set, this option is enabled by default.
+  advertise_routes:
+    name: Advertise subnet routes
+    description: >-
+      This option allows you to advertise routes to subnets (accessible on the network
+      your device is connected to) to other clients on your tailnet.
+      When not set, the add-on by default will advertise routes to your subnets on all
+      supported interfaces.
   funnel:
     name: Tailscale Funnel
     description: >-


### PR DESCRIPTION
Note: this is based on / continuation of #201, but I will rebase this PR as required.

# Proposed Changes

Make it possible to advertise not only the default routes on the managed interfaces, but user defined routes also, to support advanced networking situations (like site-to-site networking with multiple subnets, traverse multiple networks, etc.).

## Related Issues