### PR TITLE
Use new .Self.CapMap in status JSON for HTTPS support check

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/proxy/run
@@ -9,7 +9,7 @@ declare domain
 
 # Check if Tailscale HTTPS is enabled
 if ! /opt/tailscale status --self=true --peers=false --json \
-  | jq -rce ".CertDomains[0]" > /dev/null;
+  | jq -rce '.Self.CapMap | has("https")' > /dev/null;
 then
   bashio::log.notice "Tailscale's HTTPS support is disabled, therefore add-on's Tailscale Proxy functionality is disabled"
   bashio::exit.ok


### PR DESCRIPTION
# Proposed Changes

Status JSON has changed. Requires Tailscale v1.50.0 or later.

## Related Issue