### PR TITLE
Make Proxy and Funnel port configurable

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -67,6 +67,7 @@ funnel: false
 log_level: info
 login_server: "https://controlplane.tailscale.com"
 proxy: false
+proxy_and_funnel_port: 443
 snat_subnet_routes: true
 tags:
   - tag:example
@@ -158,9 +159,9 @@ More information: [Tailscale Funnel][tailscale_info_funnel]
 **Note**: _After initial setup, it can take up to 10 minutes for the domain to
 be publicly available._
 
-**Note:** _You should not use any port number in the URL that you used
+**Note:** _You should not use the port number in the URL that you used
 previously to access Home Assistant. Tailscale Funnel works on the default HTTPS
-port 443._
+port 443 (or the port configured in option `proxy_and_funnel_port`)._
 
 **Note:** _If you encounter strange browser behaviour or strange error messages,
 try to clear all site related cookies, clear all browser cache, restart browser._
@@ -234,9 +235,19 @@ More information: [Enabling HTTPS][tailscale_info_https]
 
 1. Restart the add-on.
 
-**Note:** _You should not use any port number in the URL that you used
+**Note:** _You should not use the port number in the URL that you used
 previously to access Home Assistant. Tailscale Proxy works on the default HTTPS
-port 443._
+port 443 (or the port configured in option `proxy_and_funnel_port`)._
+
+### Option: `proxy_and_funnel_port`
+
+This option allows you to configure the port the Tailscale Proxy and Funnel
+features are accessible on the tailnet (in case of Tailscale Proxy is enabled)
+and optionally on the internet (in case of Tailscale Funnel is also enabled).
+
+Only port number 443, 8443 and 10000 is allowed by Tailscale.
+
+When not set, port number 443 is used by default.
 
 ### Option: `snat_subnet_routes`
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -35,6 +35,7 @@ schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?
   proxy: bool?
+  proxy_and_funnel_port: list(443|8443|10000)?
   snat_subnet_routes: bool?
   tags:
     - "match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/serve/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/serve/run
@@ -63,4 +63,4 @@ else
 fi
 
 # Set up serve
-exec /opt/tailscale ${tailscale_command} --https=443 --set-path=/ "http://127.0.0.1:$(bashio::core.port)"
+exec /opt/tailscale ${tailscale_command} --https=$(bashio::config "proxy_and_funnel_port" "443") --set-path=/ "http://127.0.0.1:$(bashio::core.port)"

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -50,6 +50,12 @@ configuration:
       This option allows you to enable Tailscale's Proxy feature to present your
       Home Assistant instance on your tailnet with a valid certificate.
       When not set, this option is disabled by default.
+  proxy_and_funnel_port:
+    name: Tailscale Proxy and Funnel port
+    description: >-
+      This option allows you to configure the port the Tailscale Proxy and Funnel
+      features are accessible on.
+      Only port number 443, 8443 and 10000 is allowed by Tailscale.
   snat_subnet_routes:
     name: Source NAT subnet routes
     description: >-


### PR DESCRIPTION
## Proposed Changes

Also made the port configurable. Proxy and Funnel are using the same port, so making 2 port configs and dropping the current `proxy: bool?` and `funnel: bool?` configs can't be done. So 443 by default is configured as port, but this won't start proxy or funnel automatically.

## Related Issues

fixes #276