### PR TITLE
Add support for configurable proxy target port

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -69,6 +69,7 @@ advertise_routes:
 log_level: info
 login_server: "https://controlplane.tailscale.com"
 proxy: true
+proxy_target_port: 8123 
 snat_subnet_routes: true
 tags:
   - tag:example
@@ -271,6 +272,11 @@ More information: [Enabling HTTPS][tailscale_info_https]
 **Note:** _You should not use any port number in the URL that you used
 previously to access Home Assistant. Tailscale Proxy works on the default HTTPS
 port 443._
+
+### Option: `proxy_target_port`
+
+Allows you to specify an alternative port for the proxy setup. Useful when setting up a reverse proxy using, for example, the Nginx add-on.
+When not specified, this option will default to the Home Assistant core port.
 
 ### Option: `snat_subnet_routes`
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -37,6 +37,7 @@ schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?
   proxy: bool?
+  proxy_target_port: int?
   snat_subnet_routes: bool?
   tags: ["match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"]
   taildrop: bool?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/proxy/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/proxy/run
@@ -6,6 +6,7 @@
 # ==============================================================================
 
 declare domain
+declare proxy_target_port
 
 # Check if Tailscale HTTPS is enabled
 if ! /opt/tailscale status --self=true --peers=false --json \
@@ -25,10 +26,18 @@ fi
 
 # Set up proxy
 # Note: Configuration is persistent between reboots, though configuring the same value won't cause duplicate entries,
-#       but will overwite previous entry if core.port has been changed
+#       but will overwrite the previous entry if core.port has been changed
 # Note: If a tailnet node is renamed, there will be deprecated entries in status json under .Web.<different-domain:443>,
 #       those can't be removed, no command for that situation currently
-if ! /opt/tailscale serve https:443 / "http://127.0.0.1:$(bashio::core.port)"; then
+
+# Check if proxy_target_port is configured in the add-on settings
+if bashio::config.has_value 'proxy_target_port'; then
+  proxy_target_port=$(bashio::config 'proxy_target_port')
+else
+  proxy_target_port=$(bashio::core.port)
+fi
+
+if ! /opt/tailscale serve https:443 / "http://127.0.0.1:${proxy_target_port}"; then
   bashio::log.error "Unable to configure Tailscale Proxy"
   bashio::exit.nok
 fi

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -50,6 +50,11 @@ configuration:
       This option allows you to enable Tailscale's Proxy feature to present your
       Home Assistant instance on your tailnet with a valid certificate.
       When not set, this option is enabled by default.
+  proxy_target_port:
+    name: Proxy Target Port
+    description: >-
+      Allows you to specify an alternative port for the proxy setup. Useful when setting up a reverse proxy.
+      When not set, this option defaults to the Home Assistant core port.
   snat_subnet_routes:
     name: Source NAT subnet routes
     description: >-


### PR DESCRIPTION
## New Feature: Specify Proxy Target Port

### Description

This PR adds a new feature that allows users to specify an alternative port for the Tailscale proxy setup. Useful for setting up a reverse proxy, e.g., with the Nginx add-on. Defaults to the Home Assistant core port if not specified.

### Changes

- **Configuration**: Added `proxy_target_port` to `config.yaml`.
- **Documentation**: Updated `DOCS.md` to include the new option.
- **Run Script (`s6-rc.d/proxy/run`)**: Modified to read the `proxy_target_port` option.
- **Translation**: Added an entry for the new option.