### PR TITLE
Make auth-key configurable

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -63,7 +63,7 @@ advertise_exit_node: true
 advertise_routes:
   - 192.168.1.0/24
   - fd12:3456:abcd::/64
-auth_key: "tskey-abcdef1432341818"
+auth_key: "tskey-auth-xxx"
 funnel: false
 log_level: info
 login_server: "https://controlplane.tailscale.com"
@@ -126,8 +126,9 @@ supported interfaces.
 
 ### Option: `auth_key`
 
-Pre-authentication keys let you register new nodes without needing to sign in
-via a web browser.
+This options allows to couple your Home Assistant instance with your Tailscale
+account using an Auth key instead of the regular authentication flow using the
+Web UI.
 
 More information: [Auth keys][tailscale_info_auth_keys]
 

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -63,6 +63,7 @@ advertise_exit_node: true
 advertise_routes:
   - 192.168.1.0/24
   - fd12:3456:abcd::/64
+auth_key: "tskey-abcdef1432341818"
 funnel: false
 log_level: info
 login_server: "https://controlplane.tailscale.com"
@@ -122,6 +123,13 @@ More information: [Subnet routers][tailscale_info_subnets]
 
 When not set, the add-on by default will advertise routes to your subnets on all
 supported interfaces.
+
+### Option: `auth_key`
+
+Pre-authentication keys let you register new nodes without needing to sign in
+via a web browser.
+
+More information: [Auth keys][tailscale_info_auth_keys]
 
 ### Option: `funnel`
 
@@ -364,6 +372,7 @@ SOFTWARE.
 [tailscale_acls]: https://login.tailscale.com/admin/acls
 [tailscale_dns]: https://login.tailscale.com/admin/dns
 [tailscale_info_acls]: https://tailscale.com/kb/1068/acl-tags/
+[tailscale_info_auth_keys]: https://tailscale.com/kb/1085/auth-keys
 [tailscale_info_exit_nodes]: https://tailscale.com/kb/1103/exit-nodes/
 [tailscale_info_funnel]: https://tailscale.com/kb/1223/tailscale-funnel/
 [tailscale_info_funnel_policy_requirement]: https://tailscale.com/kb/1223/tailscale-funnel/#tailnet-policy-file-requirement

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -31,6 +31,7 @@ schema:
   advertise_exit_node: bool?
   advertise_routes:
     - "match(^(((25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\/(3[0-2]|[12]?\\d)|[a-fA-F\\d.:]+:[a-fA-F\\d.:]+\\/(12[0-8]|(1[01]|[1-9]?)\\d))$)?"
+  auth_key: str?
   funnel: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -8,6 +8,7 @@ declare -a options
 declare -a routes=()
 declare route
 declare -a colliding_routes=()
+declare auth_key
 declare login_server
 declare tags
 declare keyexpiry
@@ -40,6 +41,13 @@ then
   options+=(--advertise-exit-node)
 else
   options+=(--advertise-exit-node=false)
+fi
+
+# Use configured auth-key
+if bashio::config.has_value "auth_key";
+then
+  auth_key=$(bashio::config "auth_key")
+  options+=(--auth-key="${auth_key}")
 fi
 
 # Get configured control server

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -27,10 +27,11 @@ configuration:
       When not set, the add-on by default will advertise routes to your subnets on all
       supported interfaces.
   auth_key:
-    name: Pre-authentication key
+    name: Auth key
     description: >-
-      Pre-authentication keys let you register new nodes without needing to sign in
-      via a web browser.
+      This options allows to couple your Home Assistant instance with your Tailscale
+      account using an Auth key instead of the regular authentication flow using the
+      Web UI.
   funnel:
     name: Tailscale Funnel
     description: >-

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -26,6 +26,11 @@ configuration:
       your device is connected to) to other clients on your tailnet.
       When not set, the add-on by default will advertise routes to your subnets on all
       supported interfaces.
+  auth_key:
+    name: Pre-authentication key
+    description: >-
+      Pre-authentication keys let you register new nodes without needing to sign in
+      via a web browser.
   funnel:
     name: Tailscale Funnel
     description: >-


### PR DESCRIPTION
## Proposed Changes

Adds an optional `auth_key` to the config to be used in `tailscale up`

***Note:*** There is a tailscale bug (https://github.com/tailscale/tailscale/issues/9715) that makes non-reusable Auth keys unusable/broken (in general, not only in this add-on), so please test it with reusable Auth keys!

## Related Issues

fixes #266
