### PR TITLE
Protect local subnets only if accepting routes are enabled

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -98,8 +98,11 @@ fi
 
 bashio::log.info "Tailscale is running"
 
-# Notify about colliding subnet routes if non-userspace-networking is enabled
-if bashio::config.false "userspace_networking"; then
+# Warn about colliding subnet routes if non-userspace networking and accepting routes are enabled
+if bashio::config.false "userspace_networking" && \
+  (! bashio::config.has_value "accept_routes" || \
+    bashio::config.true "accept_routes");
+then
   readarray -t colliding_routes < <( \
     comm -1 -2 \
       <(subnet-routes local) \

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -5,14 +5,19 @@
 # S6 Overlay stage2 hook to customize services
 # ==============================================================================
 
-# Disable protect-subnets service when userspace-networking is enabled
+# Disable protect-subnets service when userspace-networking is enabled or accepting routes is disabled
+if ! bashio::config.has_value "userspace_networking" || \
+    bashio::config.true "userspace_networking" || \
+    bashio::config.false "accept_routes";
+then
+    rm /etc/s6-overlay/s6-rc.d/user/contents.d/protect-subnets
+    rm /etc/s6-overlay/s6-rc.d/post-tailscaled/dependencies.d/protect-subnets
+fi
+
 # Disable mss-clamping service when userspace-networking is enabled
 if ! bashio::config.has_value "userspace_networking" || \
     bashio::config.true "userspace_networking";
 then
-    rm /etc/s6-overlay/s6-rc.d/user/contents.d/protect-subnets
-    rm /etc/s6-overlay/s6-rc.d/post-tailscaled/dependencies.d/protect-subnets
-
     rm /etc/s6-overlay/s6-rc.d/user/contents.d/mss-clamping
 fi
 


### PR DESCRIPTION
# Proposed Changes

Protect local subnets only if non-userspace networking is used ***and accepting routes are enabled***.

Small code improvement moved into separate PR from #274.

## Related Issues
