### PR TITLE
Advanced Tailscale Proxy and Funnel configuration

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -118,7 +118,7 @@ working properly.
 Recommended steps to configure:
 
 1. Login to this add-on's container with
-   `docker exec -it addon_09716aab_tailscale /bin/bash`
+   `docker exec -it addon_a0d7b954_tailscale /bin/bash`
 
 1. Fine tune your tailscale settings with manual `/opt/tailscale serve --bg ...` and
    `/opt/tailscale funnel --bg ...` commands.

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -118,7 +118,7 @@ working properly.
 Recommended steps to configure:
 
 1. Login to this add-on's container with `docker exec -it
-   addon_09716aab_tailscale /bin/bash`
+addon_09716aab_tailscale /bin/bash`
 
 1. Fine tune your tailscale settings with manual `/opt/tailscale serve --bg ...` and
    `/opt/tailscale funnel --bg ...` commands.

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -59,6 +59,7 @@ device. See [Key expiry][tailscale_info_key_expiry] for more information.
 ```yaml
 accept_dns: true
 accept_routes: true
+advanced_config: false
 advertise_exit_node: true
 advertise_routes:
   - 192.168.1.0/24
@@ -95,6 +96,36 @@ your tailnet.
 More information: [Subnet routers][tailscale_info_subnets]
 
 When not set, this option is enabled by default.
+
+### Option: `advanced_config`
+
+This option overrides the add-on's Tailscale Proxy and Tailscale Funnel
+settings, they will not have any effect when this option is enabled. The add-on
+will not change any proxy or funnel related tailscale settings on startup.
+Tailscale will save and reuse any manually configured settings.
+
+**Important:** See also the "Option: `proxy`" and "Option: `funnel`" sections of
+this documentation for the necessary configuration changes in Home Assistant and
+at tailscale!
+
+When not set, this option is disabled by default.
+
+This option is for advanced users who really know what they are doing. Though it
+is recommended even for them, to set up proxy and funnel at first, and only
+start advanced manual configuration when the basic proxy and funnel features are
+working properly.
+
+Recommended steps to configure:
+
+1. Login to this add-on's container with `docker exec -it
+   addon_09716aab_tailscale /bin/bash`
+
+1. Fine tune your tailscale settings with manual `/opt/tailscale serve --bg ...` and
+   `/opt/tailscale funnel --bg ...` commands.
+
+1. Enable the `advanced_config` option.
+
+1. Restart the add-on.
 
 ### Option: `advertise_exit_node`
 

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -117,8 +117,8 @@ working properly.
 
 Recommended steps to configure:
 
-1. Login to this add-on's container with `docker exec -it
-addon_09716aab_tailscale /bin/bash`
+1. Login to this add-on's container with
+   `docker exec -it addon_09716aab_tailscale /bin/bash`
 
 1. Fine tune your tailscale settings with manual `/opt/tailscale serve --bg ...` and
    `/opt/tailscale funnel --bg ...` commands.

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -118,7 +118,7 @@ working properly.
 Recommended steps to configure:
 
 1. Login to this add-on's container with
-   `docker exec -it addon_a0d7b954_tailscale /bin/bash`
+   ``docker exec -it `docker ps -q -f name=tailscale` /bin/bash``
 
 1. Fine tune your tailscale settings with manual `/opt/tailscale serve --bg ...` and
    `/opt/tailscale funnel --bg ...` commands.

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -28,6 +28,7 @@ map:
 schema:
   accept_dns: bool?
   accept_routes: bool?
+  advanced_config: bool?
   advertise_exit_node: bool?
   advertise_routes:
     - "match(^(((25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\/(3[0-2]|[12]?\\d)|[a-fA-F\\d.:]+:[a-fA-F\\d.:]+\\/(12[0-8]|(1[01]|[1-9]?)\\d))$)?"

--- a/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
+++ b/tailscale/rootfs/etc/s6-overlay/scripts/stage2_hook.sh
@@ -25,3 +25,9 @@ fi
 if bashio::config.false 'taildrop'; then
     rm /etc/s6-overlay/s6-rc.d/user/contents.d/taildrop
 fi
+
+# Disable proxy and funnel service when advanced_config has been enabled
+if bashio::config.true "advanced_config"; then
+    rm /etc/s6-overlay/s6-rc.d/user/contents.d/proxy
+    rm /etc/s6-overlay/s6-rc.d/user/contents.d/funnel
+fi

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -12,6 +12,13 @@ configuration:
       This option allows you to accept subnet routes advertised by other nodes
       in your tailnet.
       When not set, this option is enabled by default.
+  advanced_config:
+    name: Advanced (Tailscale Proxy and Funnel) config
+    description: >-
+      This option overrides the add-on's Tailscale Proxy and Tailscale Funnel
+      settings. The add-on will not change any proxy or funnel related tailscale
+      settings on startup.
+      When not set, this option is disabled by default.
   advertise_exit_node:
     name: Advertise as an exit node
     description: >-


### PR DESCRIPTION
# Proposed Changes

Enable users to make custom tailscale serve and funnel configs. Only a 1 bit config, and nearly nothing to do in the add-on's code.

When enabled, all proxy and funnel manipulation is disabled in the add-on. Tailscale serve/funnel will remember the settings on their own:
- previously created by the add-on, or
- by the user executing tailscale serve/funnel commands, or
- by even the not-yet-existing tailscale UI.

## Related Issues

Closes PR #277 #278 Issue #276
