### PR TITLE
Cleanup ip6tables

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_18/{{package}}"
+      "depNameTemplate": "alpine_3_19/{{package}}"
     },
     {
       "fileMatch": ["/Dockerfile$"],

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -10,7 +10,6 @@ ARG BUILD_ARCH=amd64
 ARG TAILSCALE_VERSION="v1.56.1"
 RUN \
     apk add --no-cache \
-        ip6tables=1.8.9-r2 \
         ipcalc=1.0.2-r0 \
         iproute2=6.3.0-r0 \
         iptables=1.8.9-r2 \


### PR DESCRIPTION
# Proposed Changes

Base image v15 also bumped alpine version.

Also remove ip6tables reference, because it is part of the plain iptables from v3.19.

## Related Issues
