### PR TITLE
Clamp the MSS for IPv6 also

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
@@ -13,6 +13,14 @@ for interface in $( \
   | { grep -E '^-A FORWARD -i tailscale\d' || true ;} \
   | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p')
 do
-  bashio::log.info "Removing the MSS clamping for interface ${interface}"
+  bashio::log.info "Removing the MSS clamping for interface ${interface} (IPv4)"
   iptables -t mangle -D FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+done
+for interface in $( \
+  ip6tables -t mangle -S FORWARD \
+  | { grep -E '^-A FORWARD -i tailscale\d' || true ;} \
+  | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p')
+do
+  bashio::log.info "Removing the MSS clamping for interface ${interface} (IPv6)"
+  ip6tables -t mangle -D FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 done

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -41,7 +41,7 @@ if (( 0 < ${#routes[@]} )); then
     readarray -t interfaces < <(printf "%s" "${interfaces[@]/%/$'\n'}" | sort -u)
 
     for interface in "${interfaces[@]}"; do
-      bashio::log.info "  Clamping the MSS for interface ${interface}"
+      bashio::log.info "  Clamping the MSS for interface ${interface} (IPv4)"
       if [[ "${interface}" == $(iptables -t mangle -S FORWARD \
         | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
         | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
@@ -49,6 +49,15 @@ if (( 0 < ${#routes[@]} )); then
         bashio::log.notice "  MSS is already clamped for interface ${interface}"
       else
         iptables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+      fi
+      bashio::log.info "  Clamping the MSS for interface ${interface} (IPv6)"
+      if [[ "${interface}" == $(ip6tables -t mangle -S FORWARD \
+        | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
+        | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
+      then
+        bashio::log.notice "  MSS is already clamped for interface ${interface}"
+      else
+        ip6tables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
       fi
     done
   fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -46,7 +46,7 @@ if (( 0 < ${#routes[@]} )); then
         | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
         | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
       then
-        bashio::log.notice "  MSS is already clamped for interface ${interface}"
+        bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv4)"
       else
         iptables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
       fi
@@ -55,7 +55,7 @@ if (( 0 < ${#routes[@]} )); then
         | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
         | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
       then
-        bashio::log.notice "  MSS is already clamped for interface ${interface}"
+        bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv6)"
       else
         ip6tables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
       fi


### PR DESCRIPTION
# Proposed Changes

Bugfix: Clamping was done for IPv4 only, this adds it for IPv6 traffic also.

## Related Issues
