### PR TITLE
Increase wait time for Supervisor

### DIFF
--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -22,12 +22,12 @@ if bashio::config.false "userspace_networking"; then
   # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
   # So we wait a little
   while ! bashio::api.supervisor GET "/addons/self/options/config" false &> /dev/null; do
-    if (( wait_counter++ == 15 )); then
+    if (( wait_counter++ == 18 )); then
       bashio::log.error "Supervisor is unreachable"
       bashio::exit.nok
     fi
     bashio::log.info "Waiting for the supervisor to be ready..."
-    sleep 2
+    sleep 5
   done
   if (( wait_counter != 0 )); then
     bashio::log.info "Supervisor is ready"


### PR DESCRIPTION
# Proposed Changes

Just a small improvement.

Currently it waits only 30s, but after a SU update the restart can take easily 10 seconds, so increase it from 30 (15 x 2s) to 90s (18 x 5s).

```
[14:45:36] INFO: Removing route 192.168.1.0/24 from ip rules
[14:45:37] INFO: Waiting for the supervisor to be ready...
[14:45:40] INFO: Waiting for the supervisor to be ready...
[14:45:42] INFO: Waiting for the supervisor to be ready...
[14:45:44] INFO: Supervisor is ready
[14:45:45] INFO: Adding local subnets to ip rules with higher priority than Tailscale's routing,
```

## Related Issues
