### PR TITLE
Use regex for Proxy and Funnel port configuration validation

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -35,7 +35,7 @@ schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?
   proxy: bool?
-  proxy_and_funnel_port: list(443|8443|10000)?
+  proxy_and_funnel_port: match(^(443|8443|10000)$)?
   snat_subnet_routes: bool?
   tags:
     - "match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"


### PR DESCRIPTION
# Proposed Changes

Though this way it is easier to enter a wrong value, like 444, but this will give an error in the UI at least.

With this modification the value won't be inside a `"..."` in the YAML.

## Related Issues

Follow up on #277
