### PR TITLE
Fix kernel configuration access for Debian Supervised installations

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -18,7 +18,7 @@ if (( 0 < ${#routes[@]} )); then
   bashio::log.info "Clamping the MSS to the MTU for all advertised subnet's interface,"
   bashio::log.info "to support site-to-site networking better"
 
-  if (( 0 == $(zcat /proc/config.gz | { grep -Ec '^CONFIG_NETFILTER_XT_TARGET_TCPMSS=.$' || true ;}) )); then
+  if (( 0 == $(kernel-config | { grep -Ec '^CONFIG_NETFILTER_XT_TARGET_TCPMSS=.$' || true ;}) )); then
     bashio::log.warning "Altering the MSS is not supported due to missing kernel module,"
     bashio::log.warning "skip clamping the MSS to the MTU for all advertised subnet's interface"
   else

--- a/tailscale/rootfs/usr/bin/kernel-config
+++ b/tailscale/rootfs/usr/bin/kernel-config
@@ -1,0 +1,7 @@
+#!/command/with-contenv bashio
+
+if bashio::fs.file_exists /proc/config.gz; then
+  zcat /proc/config.gz
+else
+  cat /boot/config-$(uname -r)
+fi

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -14,8 +14,8 @@ declare response
 declare wait_counter=0
 
 if bashio::config.false "userspace_networking"; then
-  ipv4_multiple_tables_enabled=$(zcat /proc/config.gz | { grep -Ec '^CONFIG_IP_MULTIPLE_TABLES=y$' || true ;})
-  ipv6_multiple_tables_enabled=$(zcat /proc/config.gz | { grep -Ec '^CONFIG_IPV6_MULTIPLE_TABLES=y$' || true ;})
+  ipv4_multiple_tables_enabled=$(kernel-config | { grep -Ec '^CONFIG_IP_MULTIPLE_TABLES=y$' || true ;})
+  ipv6_multiple_tables_enabled=$(kernel-config | { grep -Ec '^CONFIG_IPV6_MULTIPLE_TABLES=y$' || true ;})
 
   # If it is called after network configuration is changed, we need to drop cached network info
   bashio::cache.flush_all


### PR DESCRIPTION
# Proposed Changes

In case of Debian/Supervised installations use `cat /boot/config-$(uname -r)` instead of `zcat /proc/config.gz`

## Related Issues

fixes #325 #316
