### PR TITLE
Drop kernel configuration access

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -18,47 +18,48 @@ if (( 0 < ${#routes[@]} )); then
   bashio::log.info "Clamping the MSS to the MTU for all advertised subnet's interface,"
   bashio::log.info "to support site-to-site networking better"
 
-  if (( 0 == $(kernel-config | { grep -Ec '^CONFIG_NETFILTER_XT_TARGET_TCPMSS=.$' || true ;}) )); then
-    bashio::log.warning "Altering the MSS is not supported due to missing kernel module,"
-    bashio::log.warning "skip clamping the MSS to the MTU for all advertised subnet's interface"
-  else
-    # Find interfaces for subnet routes
-    for route in "${routes[@]}"; do
-      if [[ "${route}" =~ .*:.* ]]; then
-        family="-6"
-      else
-        family="-4"
-      fi
-      for interface in $( \
-        ip "${family}" -json route show to match "${route}" \
-        | jq --raw-output -c -M '.[].dev')
-      do
-        interfaces+=("${interface}")
-      done
+  # Find interfaces for subnet routes
+  for route in "${routes[@]}"; do
+    if [[ "${route}" =~ .*:.* ]]; then
+      family="-6"
+    else
+      family="-4"
+    fi
+    for interface in $( \
+      ip "${family}" -json route show to match "${route}" \
+      | jq --raw-output -c -M '.[].dev')
+    do
+      interfaces+=("${interface}")
     done
+  done
 
-    # Remove duplicate entries
-    readarray -t interfaces < <(printf "%s" "${interfaces[@]/%/$'\n'}" | sort -u)
+  # Remove duplicate entries
+  readarray -t interfaces < <(printf "%s" "${interfaces[@]/%/$'\n'}" | sort -u)
 
-    for interface in "${interfaces[@]}"; do
-      bashio::log.info "  Clamping the MSS for interface ${interface} (IPv4)"
-      if [[ "${interface}" == $(iptables -t mangle -S FORWARD \
-        | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
-        | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
-      then
-        bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv4)"
-      else
-        iptables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+  for interface in "${interfaces[@]}"; do
+    bashio::log.info "  Clamping the MSS for interface ${interface} (IPv4)"
+    if [[ "${interface}" == $(iptables -t mangle -S FORWARD \
+      | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
+      | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
+    then
+      bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv4)"
+    else
+      if ! iptables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu; then
+        bashio::log.warning "Altering the MSS for site-to-site networking is unsuccessful"
+        break
       fi
-      bashio::log.info "  Clamping the MSS for interface ${interface} (IPv6)"
-      if [[ "${interface}" == $(ip6tables -t mangle -S FORWARD \
-        | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
-        | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
-      then
-        bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv6)"
-      else
-        ip6tables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+    fi
+    bashio::log.info "  Clamping the MSS for interface ${interface} (IPv6)"
+    if [[ "${interface}" == $(ip6tables -t mangle -S FORWARD \
+      | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
+      | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
+    then
+      bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv6)"
+    else
+      if ! ip6tables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu; then
+        bashio::log.warning "Altering the MSS for site-to-site networking is unsuccessful"
+        break
       fi
-    done
-  fi
+    fi
+  done
 fi

--- a/tailscale/rootfs/usr/bin/kernel-config
+++ b/tailscale/rootfs/usr/bin/kernel-config
@@ -1,7 +1,0 @@
-#!/command/with-contenv bashio
-
-if bashio::fs.file_exists /proc/config.gz; then
-  zcat /proc/config.gz
-else
-  cat /boot/config-$(uname -r)
-fi

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -7,16 +7,10 @@
 
 declare -a routes=()
 declare route family
-declare ipv4_multiple_tables_enabled
-declare ipv6_multiple_tables_enabled
-declare protected_routes=0
 declare response
 declare wait_counter=0
 
 if bashio::config.false "userspace_networking"; then
-  ipv4_multiple_tables_enabled=$(kernel-config | { grep -Ec '^CONFIG_IP_MULTIPLE_TABLES=y$' || true ;})
-  ipv6_multiple_tables_enabled=$(kernel-config | { grep -Ec '^CONFIG_IPV6_MULTIPLE_TABLES=y$' || true ;})
-
   # If it is called after network configuration is changed, we need to drop cached network info
   bashio::cache.flush_all
   # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
@@ -40,16 +34,8 @@ if bashio::config.false "userspace_networking"; then
   fi
   for route in "${routes[@]}"; do
     if [[ "${route}" =~ .*:.* ]]; then
-      if (( 0 == ${ipv6_multiple_tables_enabled} )); then
-        bashio::log.warning "  IPv6 multiple routing tables are not enabled, skip adding route ${route} to ip rules"
-        continue
-      fi
       family="-6"
     else
-      if (( 0 == ${ipv4_multiple_tables_enabled} )); then
-        bashio::log.warning "  IPv4 multiple routing tables are not enabled, skip adding route ${route} to ip rules"
-        continue
-      fi
       family="-4"
     fi
     bashio::log.info "  Adding route ${route} to ip rules"
@@ -61,10 +47,5 @@ if bashio::config.false "userspace_networking"; then
         bashio::log.notice "  Route ${route} is already added to ip rules"
       fi
     fi
-    (( protected_routes+=1 ))
   done
-  if (( 0 < ${#routes[@]} && 0 == ${protected_routes} )); then
-    bashio::log.error "Can't protect any subnets"
-    bashio::exit.nok
-  fi
 fi


### PR DESCRIPTION
# Proposed Changes

Drop accessing `/boot/config-$(uname -r)` or `/proc/config.gz`:
- It was placed there mainly because some of the HA OS images had different routing capabilities, but it was already fixed by the OS team (see https://github.com/home-assistant/operating-system/issues/3026 and https://github.com/home-assistant/operating-system/pull/3027).
- The other kernel config check is TCPMSS related, but that results only in a warning, so we can test whether that TCPMSS manipulation fails and emit a warning then, and do not check the kernel config in advance.

## Related Issues

really fixes #325