### PR TITLE
Use web as a command, not as an option

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/run
@@ -8,9 +8,8 @@ declare -a options
 
 bashio::log.info 'Starting Tailscale web...'
 
-options+=(web)
 # Get random port
 options+=(--listen 127.0.0.1:25899)
 
 # Run Tailscale
-exec /opt/tailscale "${options[@]}"
+exec /opt/tailscale web "${options[@]}"


### PR DESCRIPTION
# Proposed Changes

Minor code quality improvement. No functional change.

Use `web` as `file`, `up`, `serve`, etc.

## Related Issues
