### PR TITLE
Use readonly webui mode in v1.60

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -56,6 +56,11 @@ supported interfaces to Tailscale.
 Consider disabling key expiry to avoid losing connection to your Home Assistant
 device. See [Key expiry][tailscale_info_key_expiry] for more information.
 
+**Note:** _Some of the options below also available on Tailscale's web interface
+through the Web UI, but they are made read only there. You can't change them
+through the Web UI, because all the changes made there would be lost when the
+add-on is restarted._
+
 ```yaml
 accept_dns: true
 accept_routes: true

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/web/run
@@ -11,5 +11,9 @@ bashio::log.info 'Starting Tailscale web...'
 # Get random port
 options+=(--listen 127.0.0.1:25899)
 
+# Use readonly webui mode
+# Note: can be removed later, after most of the add-on config options are available through the webui
+options+=(--readonly)
+
 # Run Tailscale
 exec /opt/tailscale web "${options[@]}"


### PR DESCRIPTION
# Proposed Changes

Until tailscale webui doesn't make available most of the add-on config options, it is better to make it readonly. If it is not readonly, changed values will be lost after the next add-on restart.

## Related Issues

closes #314