### PR TITLE
Change to tag validation regex to allow more flexibility in hypen use

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -38,6 +38,6 @@ schema:
   proxy_and_funnel_port: match(^(443|8443|10000)$)?
   snat_subnet_routes: bool?
   tags:
-    - "match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"
+    - "match(^tag:[a-zA-Z0-9-]+$)?"
   taildrop: bool?
   userspace_networking: bool?


### PR DESCRIPTION
# Proposed Changes

> I wanted to apply "tag:home-automation" to my HomeAssistant. This generated a regex validation error while "tag:h-omeautomation" was accepted. I didn't find Tailscale's regex for tags so I'm proposing a revision to accept multiple hyphens and in multiple locations. Tested against example tags in [Common Patterns for Tag Names](https://tailscale.com/kb/1068/acl-tags#common-patterns-for-tag-names)

## Related Issues

> N/A. [commit c9c96aa](https://github.com/noconnor29/addon-tailscale-tag-regex/commit/c9c96aa2bdfa3612d763873aeb6e2478a9a69d55)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
