### PR TITLE
Tag names must start with a letter after 'tag:' and contain letters, …

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -38,6 +38,6 @@ schema:
   proxy_and_funnel_port: match(^(443|8443|10000)$)?
   snat_subnet_routes: bool?
   tags:
-    - "match(^tag:[a-zA-Z0-9]-?[a-zA-Z0-9]+$)?"
+    - "match(^tag:[a-zA-Z][a-zA-Z0-9-]*$)?"
   taildrop: bool?
   userspace_networking: bool?


### PR DESCRIPTION
Tag names must start with a letter after 'tag:' and contain letters, numbers, or dashes

# Proposed Changes

I wanted to apply "tag:home-automation" to my HomeAssistant. This generated a regex validation error while "tag:h-omeautomation" was accepted. I didn't find Tailscale's regex for tags so I'm proposing a revision to accept multiple hyphens and in multiple locations. Tested against example tags in [Common Patterns for Tag Names](https://tailscale.com/kb/1068/acl-tags#common-patterns-for-tag-names)

Tested combinations to find Tailscale requires tags start with a letter and are composed of letters, numbers and dashes. Tags can be a single letter, e.g. "tag:a", and can end in a dash.

## Related Issues
[Commit 448b965](https://github.com/noconnor29/addon-tailscale-tag-regex/commit/448b965440750be0eb9dbb00fc2c13d0f40ce4f8)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
