### PR TITLE
Add app connector option

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -65,6 +65,7 @@ add-on is restarted._
 accept_dns: true
 accept_routes: true
 advertise_exit_node: true
+advertise_connector: true
 advertise_routes:
   - 192.168.1.0/24
   - fd12:3456:abcd::/64
@@ -110,6 +111,22 @@ By setting a device on your network as an exit node, you can use it to
 route all your public internet traffic as needed, like a consumer VPN.
 
 More information: [Exit nodes][tailscale_info_exit_nodes]
+
+When not set, this option is enabled by default.
+
+### Option: `advertise_connector`
+
+This option allows you to advertise this Tailscale instance as an app connector.
+
+When you use an app connector, you specify which applications you wish to make
+accessible over your tailnet, and the domains for those applications. Any traffic
+for that application is then forced over the tailnet to a node running an app
+connector before egressing to the target domains. This is useful for cases where
+the application has an allowlist of IP addresses which can connect to it: the IP
+address of the node running the app connector can be added to the allowlist, and
+all nodes on the tailnet will use that IP address for their traffic egress.
+
+More information: [App connectors][tailscale_info_app_connectors]
 
 When not set, this option is enabled by default.
 
@@ -381,6 +398,7 @@ SOFTWARE.
 [tailscale_dns]: https://login.tailscale.com/admin/dns
 [tailscale_info_acls]: https://tailscale.com/kb/1068/acl-tags/
 [tailscale_info_exit_nodes]: https://tailscale.com/kb/1103/exit-nodes/
+[tailscale_info_app_connectors]: https://tailscale.com/kb/1281/app-connectors
 [tailscale_info_funnel]: https://tailscale.com/kb/1223/tailscale-funnel/
 [tailscale_info_funnel_policy_requirement]: https://tailscale.com/kb/1223/tailscale-funnel/#tailnet-policy-file-requirement
 [tailscale_info_https]: https://tailscale.com/kb/1153/enabling-https/

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -29,6 +29,7 @@ schema:
   accept_dns: bool?
   accept_routes: bool?
   advertise_exit_node: bool?
+  advertise_connector: bool?
   advertise_routes:
     - "match(^(((25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\/(3[0-2]|[12]?\\d)|[a-fA-F\\d.:]+:[a-fA-F\\d.:]+\\/(12[0-8]|(1[01]|[1-9]?)\\d))$)?"
   funnel: bool?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -42,6 +42,15 @@ else
   options+=(--advertise-exit-node=false)
 fi
 
+# Advertise app connector by default when not set, or when explicitly enabled
+if ! bashio::config.has_value "advertise_connector" || \
+  bashio::config.true "advertise_connector";
+then
+  options+=(--advertise-connector)
+else
+  options+=(--advertise-connector=false)
+fi
+
 # Get configured control server
 if bashio::config.has_value "login_server";
 then

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -19,6 +19,16 @@ configuration:
       By setting a device on your network as an exit node, you can use it to
       route all your public internet traffic as needed, like a consumer VPN.
       When not set, this option is enabled by default.
+  advertise_connector:
+    name: Advertise as an app connector
+    description: >-
+      When you use an app connector, you specify which applications you wish to make
+      accessible over your tailnet, and the domains for those applications. Any traffic
+      for that application is then forced over the tailnet to a node running an app
+      connector before egressing to the target domains. This is useful for cases where
+      the application has an allowlist of IP addresses which can connect to it: the IP
+      address of the node running the app connector can be added to the allowlist, and
+      all nodes on the tailnet will use that IP address for their traffic egress.
   advertise_routes:
     name: Advertise subnet routes
     description: >-


### PR DESCRIPTION
# Proposed Changes

Add `advertise_connector` option to support the `--advertise-connector` flag to use the [app connectors feature](https://tailscale.com/kb/1281/app-connectors).

I couldn't find the option available in this add-on and wanted to try it out. Tested this feature locally and it's working great.

## Related Issues

N/A
