### PR TITLE
Linux optimizations for subnet routers and exit nodes

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -10,6 +10,7 @@ ARG BUILD_ARCH=amd64
 ARG TAILSCALE_VERSION="v1.66.0"
 RUN \
     apk add --no-cache \
+        ethtool=6.6-r0 \
         ipcalc=1.0.3-r0 \
         iproute2=6.6.0-r0 \
         iptables=1.8.10-r3 \

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -12,6 +12,12 @@ declare login_server
 declare tags
 declare keyexpiry
 
+# Linux optimizations for subnet routers and exit nodes
+# Based on: https://tailscale.com/kb/1320/performance-best-practices#linux-optimizations-for-subnet-routers-and-exit-nodes
+# Note: Changes made via ethtool are not persistent and will be lost after the machine shuts down.
+# Note: Executing it before "tailscale up" to avoid warning messages
+ethtool -K $(ip route show 0/0 | cut -f5 -d' ') rx-udp-gro-forwarding on rx-gro-list off
+
 # Default options
 options+=(--hostname "$(bashio::info.hostname)")
 


### PR DESCRIPTION
# Proposed Changes

Noticed a warning in the tailscale logs:

```
Warning: UDP GRO forwarding is suboptimally configured on enu1u1, UDP forwarding throughput capability will increase with a configuration change.
See https://tailscale.com/s/ethtool-config-udp-gro
```

The suggested change at https://tailscale.com/s/ethtool-config-udp-gro basically turns on the rx-udp-gro-forwarding feature.

Smoke tested on: HA OS (armv7l, aarch64, x86_64 (VM)), Supervised (x86_64 (VM))

## Related Issues

--