### PR TITLE
Make stateful filtering configurable

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -74,6 +74,7 @@ login_server: "https://controlplane.tailscale.com"
 proxy: false
 proxy_and_funnel_port: 443
 snat_subnet_routes: true
+stateful_filtering: true
 tags:
   - tag:example
   - tag:homeassistant
@@ -262,8 +263,29 @@ router, and this simplifies routing configuration.
 When not set, this option is enabled by default.
 
 To support advanced [Site-to-site networking][tailscale_info_site_to_site] (eg.
-to traverse multiple networks), you can disable this functionality. But do it
-only when you really understand why you need this.
+to traverse multiple networks), you can disable this functionality, and execute
+steps 2 and 3 as described on [Site-to-site
+networking][tailscale_info_site_to_site]. But do it only when you really
+understand why you need this.
+
+**Note:** If `snat_subnet_routes` is disabled, consider disabling
+`stateful_filtering` also.
+
+### Option: `stateful_filtering`
+
+This option enables stateful packet filtering on packet-forwarding nodes (exit
+nodes, subnet routers, and app connectors), to only allow return packets for
+existing outbound connections. Inbound packets that don't belong to an existing
+connection are dropped.
+
+When not set, this option is enabled by default.
+
+To support basic [Site-to-site networking][tailscale_info_site_to_site], you can
+disable this functionality, and execute steps 2 and 3 as described on
+[Site-to-site networking][tailscale_info_site_to_site].
+
+**Note:** If `snat_subnet_routes` is disabled, consider disabling
+`stateful_filtering` also.
 
 ### Option: `tags`
 
@@ -295,8 +317,8 @@ instance, disable userspace networking mode, which will create a `tailscale0`
 network interface on your host.
 
 If you want to access other clients on your tailnet even from your local subnet,
-execute steps 2 and 3 as described on [Site-to-site
-networking][tailscale_info_site_to_site].
+disable `stateful_filtering` and execute steps 2 and 3 as described on
+[Site-to-site networking][tailscale_info_site_to_site].
 
 In case your local subnets collide with subnet routes within your tailnet, your
 local network access has priority, and these addresses won't be routed toward

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -268,9 +268,6 @@ steps 2 and 3 as described on [Site-to-site
 networking][tailscale_info_site_to_site]. But do it only when you really
 understand why you need this.
 
-**Note:** If `snat_subnet_routes` is disabled, consider disabling
-`stateful_filtering` also.
-
 ### Option: `stateful_filtering`
 
 This option enables stateful packet filtering on packet-forwarding nodes (exit
@@ -283,9 +280,6 @@ When not set, this option is enabled by default.
 To support basic [Site-to-site networking][tailscale_info_site_to_site], you can
 disable this functionality, and execute steps 2 and 3 as described on
 [Site-to-site networking][tailscale_info_site_to_site].
-
-**Note:** If `snat_subnet_routes` is disabled, consider disabling
-`stateful_filtering` also.
 
 ### Option: `tags`
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -37,6 +37,7 @@ schema:
   proxy: bool?
   proxy_and_funnel_port: match(^(443|8443|10000)$)?
   snat_subnet_routes: bool?
+  stateful_filtering: bool?
   tags:
     - "match(^tag:[a-zA-Z][a-zA-Z0-9-]*$)?"
   taildrop: bool?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -55,6 +55,15 @@ then
   options+=(--login-server="${login_server}")
 fi
 
+# Support basic site-to-site networking, disable stateful filtering
+if ! bashio::config.has_value "stateful_filtering" || \
+  bashio::config.true "stateful_filtering";
+then
+  options+=(--stateful-filtering)
+else
+  options+=(--stateful-filtering=false)
+fi
+
 # Support advanced site-to-site networking, disable source addresses NAT
 if ! bashio::config.has_value "snat_subnet_routes" || \
   bashio::config.true "snat_subnet_routes";
@@ -135,6 +144,14 @@ then
   for route in "${colliding_routes[@]}"; do
     bashio::log.warning "  ${route}"
   done
+fi
+
+# Notify about unusual site-to-site networking configuration
+if (! bashio::config.has_value "stateful_filtering" || \
+    bashio::config.true "stateful_filtering") && \
+    bashio::config.false "snat_subnet_routes";
+then
+  bashio::log.notice "When snat_subnet_routes is disabled, consider disabling stateful_filtering also."
 fi
 
 # Notify about userspace networking

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -146,14 +146,6 @@ then
   done
 fi
 
-# Notify about unusual site-to-site networking configuration
-if (! bashio::config.has_value "stateful_filtering" || \
-    bashio::config.true "stateful_filtering") && \
-    bashio::config.false "snat_subnet_routes";
-then
-  bashio::log.notice "When snat_subnet_routes is disabled, consider disabling stateful_filtering also."
-fi
-
 # Notify about userspace networking
 if ! bashio::config.has_value "userspace_networking" || \
     bashio::config.true "userspace_networking";

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -64,6 +64,14 @@ configuration:
       To support advanced Site-to-site networking (eg. to traverse multiple
       networks), you can disable this functionality.
       When not set, this option is enabled by default.
+  stateful_filtering:
+    name: Stateful packet filtering
+    description: >-
+      This option enables stateful packet filtering on packet-forwarding nodes (exit
+      nodes, subnet routers, and app connectors), to only allow return packets for
+      existing outbound connections.
+      To support basic Site-to-site networking, you can disable this functionality.
+      When not set, this option is enabled by default.
   tags:
     name: Tags
     description: >-


### PR DESCRIPTION
# Proposed Changes

TS 1.66.x made `stateful-filtering` default enabled, but disabling it is required for site-to-site networking to work properly.

`stateful-filtering` is/can be independent from `snat-subnet-routes`, so a separate option is the right solution in my opinion.

(The problem is identified by @elcajon in https://github.com/lmagyar/homeassistant-addon-tailscale/issues/127)

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `stateful_filtering` option to enable or disable stateful packet filtering on certain nodes.

- **Configuration Updates**
  - Added `stateful_filtering` boolean field to the configuration schema.
  - Updated documentation and translations to reflect the new `stateful_filtering` option.

- **Networking Enhancements**
  - Added support for basic site-to-site networking with configurable stateful filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->