### PR TITLE
Reword app connector option's translation

### DIFF
--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -25,10 +25,8 @@ configuration:
       When you use an app connector, you specify which applications you wish to make
       accessible over your tailnet, and the domains for those applications. Any traffic
       for that application is then forced over the tailnet to a node running an app
-      connector before egressing to the target domains. This is useful for cases where
-      the application has an allowlist of IP addresses which can connect to it: the IP
-      address of the node running the app connector can be added to the allowlist, and
-      all nodes on the tailnet will use that IP address for their traffic egress.
+      connector before egressing to the target domains.
+      When not set, this option is enabled by default.
   advertise_routes:
     name: Advertise subnet routes
     description: >-


### PR DESCRIPTION
# Proposed Changes

- Mentioned the default config (this is there for all other options)
- Shortened the description (usually the translation is not the whole docs paragraph)

(Yes, I'm late to the party, I apologize, I should have done it as part of the original PR's (#348) review. cc @angel-urena)

## Related Issues

--

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified explanation of app connectors by removing details about IP address allowlisting.
  - Emphasized default behavior when the option is not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->