### PR TITLE
Skip default networks without a gateway to enable UDP GRO for forwarding

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -19,6 +19,7 @@ declare keyexpiry
 # Note: Executing it before "tailscale up" to avoid warning messages
 for interface in $( \
   { ip -4 route show 0/0; ip -6 route show ::/0; } \
+  | { grep -E '^default\svia\s\S+\sdev\s\S+' || true ;} \
   | cut -f5 -d' ' \
   | sort -u)
 do


### PR DESCRIPTION
# Proposed Changes

Skip default networks without a gateway to enable UDP GRO for forwarding

```
default via xxxx dev xxxx ... # This is OK 
default dev xxxx ... # This is skipped 
```

## Related Issues

fixes #364


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved route filtering in the network configuration script to better select interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->