### PR TITLE
Stateful filtering is now off by default

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -292,11 +292,7 @@ nodes, subnet routers, and app connectors), to only allow return packets for
 existing outbound connections. Inbound packets that don't belong to an existing
 connection are dropped.
 
-When not set, this option is enabled by default.
-
-To support basic [Site-to-site networking][tailscale_info_site_to_site], you can
-disable this functionality, and execute steps 2 and 3 as described on
-[Site-to-site networking][tailscale_info_site_to_site].
+When not set, this option is disabled by default.
 
 ### Option: `tags`
 
@@ -328,8 +324,8 @@ instance, disable userspace networking mode, which will create a `tailscale0`
 network interface on your host.
 
 If you want to access other clients on your tailnet even from your local subnet,
-disable `stateful_filtering` and execute steps 2 and 3 as described on
-[Site-to-site networking][tailscale_info_site_to_site].
+execute steps 2 and 3 as described on [Site-to-site
+networking][tailscale_info_site_to_site].
 
 In case your local subnets collide with subnet routes within your tailnet, your
 local network access has priority, and these addresses won't be routed toward

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -280,7 +280,7 @@ router, and this simplifies routing configuration.
 When not set, this option is enabled by default.
 
 To support advanced [Site-to-site networking][tailscale_info_site_to_site] (eg.
-to traverse multiple networks), you can disable this functionality, and execute
+to traverse multiple networks), you can disable this functionality, and follow
 steps 2 and 3 as described on [Site-to-site
 networking][tailscale_info_site_to_site]. But do it only when you really
 understand why you need this.
@@ -324,7 +324,7 @@ instance, disable userspace networking mode, which will create a `tailscale0`
 network interface on your host.
 
 If you want to access other clients on your tailnet even from your local subnet,
-execute steps 2 and 3 as described on [Site-to-site
+follow steps 2 and 3 as described on [Site-to-site
 networking][tailscale_info_site_to_site].
 
 In case your local subnets collide with subnet routes within your tailnet, your

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -72,13 +72,13 @@ then
   options+=(--login-server="${login_server}")
 fi
 
-# Support basic site-to-site networking, disable stateful filtering
+# Enable stateful filtering (it's disabled by default from v1.66.4)
 if ! bashio::config.has_value "stateful_filtering" || \
-  bashio::config.true "stateful_filtering";
+  bashio::config.false "stateful_filtering";
 then
-  options+=(--stateful-filtering)
-else
   options+=(--stateful-filtering=false)
+else
+  options+=(--stateful-filtering)
 fi
 
 # Support advanced site-to-site networking, disable source addresses NAT

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -78,8 +78,7 @@ configuration:
       This option enables stateful packet filtering on packet-forwarding nodes (exit
       nodes, subnet routers, and app connectors), to only allow return packets for
       existing outbound connections.
-      To support basic Site-to-site networking, you can disable this functionality.
-      When not set, this option is enabled by default.
+      When not set, this option is disabled by default.
   tags:
     name: Tags
     description: >-


### PR DESCRIPTION
# Proposed Changes

In TS v1.66.4 stateful filtering is off by default, the add-on follows this change. https://github.com/tailscale/tailscale/releases/tag/v1.66.4

## Related Issues

--

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for site-to-site networking in Tailscale documentation.
  - Updated default setting information for a specific option, now disabled by default.

- **New Features**
  - Enabled stateful filtering by default in the `post-tailscaled/run` script starting from version 1.66.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->