### PR TITLE
Failsafe enabling of UDP GRO for forwarding

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -4,7 +4,6 @@
 # Home Assistant Community Add-on: Tailscale
 # Runs after the machine has been logged in into the Tailscale network
 # ==============================================================================
-declare interface
 declare -a options
 declare -a routes=()
 declare route
@@ -12,20 +11,6 @@ declare -a colliding_routes=()
 declare login_server
 declare tags
 declare keyexpiry
-
-# Linux optimizations for subnet routers and exit nodes
-# Based on: https://tailscale.com/kb/1320/performance-best-practices#linux-optimizations-for-subnet-routers-and-exit-nodes
-# Note: Changes made via ethtool are not persistent and will be lost after the machine shuts down
-# Note: Executing it before "tailscale up" to avoid warning messages
-for interface in $( \
-  { ip -4 route show 0/0; ip -6 route show ::/0; } \
-  | { grep -E '^default\svia\s\S+\sdev\s\S+' || true ;} \
-  | cut -f5 -d' ' \
-  | sort -u)
-do
-  bashio::log.info "Allow UDP GRO for forwarding on ${interface}"
-  ethtool -K "${interface}" rx-udp-gro-forwarding on rx-gro-list off
-done
 
 # Default options
 options+=(--hostname "$(bashio::info.hostname)")

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -17,15 +17,16 @@ declare keyexpiry
 # Based on: https://tailscale.com/kb/1320/performance-best-practices#linux-optimizations-for-subnet-routers-and-exit-nodes
 # Note: Changes made via ethtool are not persistent and will be lost after the machine shuts down
 # Note: Executing it before "tailscale up" to avoid warning messages
-for interface in $( \
-  { ip -4 route show 0/0; ip -6 route show ::/0; } \
-  | { grep -E '^default\svia\s\S+\sdev\s\S+' || true ;} \
-  | cut -f5 -d' ' \
-  | sort -u)
-do
+# Note: Everything fails silently, we do a best effort only.
+if interface=$( \
+  curl -sf --unix-socket /var/run/tailscale/tailscaled.sock http://local-tailscaled.sock/localapi/v0/check-udp-gro-forwarding \
+  | jq -rc '.Warning' \
+  | sed -nr 's/^UDP GRO forwarding is suboptimally configured on (\S+),.*$/\1/p') \
+  && bashio::var.has_value "${interface}";
+then
   bashio::log.info "Allow UDP GRO for forwarding on ${interface}"
-  ethtool -K "${interface}" rx-udp-gro-forwarding on rx-gro-list off
-done
+  ethtool -K "${interface}" rx-udp-gro-forwarding on rx-gro-list off &> /dev/null || true
+fi
 
 # Default options
 options+=(--hostname "$(bashio::info.hostname)")

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -4,6 +4,7 @@
 # Home Assistant Community Add-on: Tailscale
 # Runs after the machine has been logged in into the Tailscale network
 # ==============================================================================
+declare interface
 declare -a options
 declare -a routes=()
 declare route
@@ -11,6 +12,20 @@ declare -a colliding_routes=()
 declare login_server
 declare tags
 declare keyexpiry
+
+# Linux optimizations for subnet routers and exit nodes
+# Based on: https://tailscale.com/kb/1320/performance-best-practices#linux-optimizations-for-subnet-routers-and-exit-nodes
+# Note: Changes made via ethtool are not persistent and will be lost after the machine shuts down
+# Note: Executing it before "tailscale up" to avoid warning messages
+for interface in $( \
+  { ip -4 route show 0/0; ip -6 route show ::/0; } \
+  | { grep -E '^default\svia\s\S+\sdev\s\S+' || true ;} \
+  | cut -f5 -d' ' \
+  | sort -u)
+do
+  bashio::log.info "Allow UDP GRO for forwarding on ${interface}"
+  ethtool -K "${interface}" rx-udp-gro-forwarding on rx-gro-list off
+done
 
 # Default options
 options+=(--hostname "$(bashio::info.hostname)")

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -13,21 +13,6 @@ declare login_server
 declare tags
 declare keyexpiry
 
-# Linux optimizations for subnet routers and exit nodes
-# Based on: https://tailscale.com/kb/1320/performance-best-practices#linux-optimizations-for-subnet-routers-and-exit-nodes
-# Note: Changes made via ethtool are not persistent and will be lost after the machine shuts down
-# Note: Executing it before "tailscale up" to avoid warning messages
-# Note: Everything fails silently, we do a best effort only.
-if interface=$( \
-  curl -sf --unix-socket /var/run/tailscale/tailscaled.sock http://local-tailscaled.sock/localapi/v0/check-udp-gro-forwarding \
-  | jq -rc '.Warning' \
-  | sed -nr 's/^UDP GRO forwarding is suboptimally configured on (\S+),.*$/\1/p') \
-  && bashio::var.has_value "${interface}";
-then
-  bashio::log.info "Allow UDP GRO for forwarding on ${interface}"
-  ethtool -K "${interface}" rx-udp-gro-forwarding on rx-gro-list off &> /dev/null || true
-fi
-
 # Default options
 options+=(--hostname "$(bashio::info.hostname)")
 
@@ -124,6 +109,20 @@ do
 done
 
 bashio::log.info "Tailscale is running"
+
+# Linux optimizations for subnet routers and exit nodes
+# Based on: https://tailscale.com/kb/1320/performance-best-practices#linux-optimizations-for-subnet-routers-and-exit-nodes
+# Note: Changes made via ethtool are not persistent and will be lost after the machine shuts down
+# Note: Everything fails silently, we do a best effort only.
+if interface=$( \
+  curl -sf --unix-socket /var/run/tailscale/tailscaled.sock http://local-tailscaled.sock/localapi/v0/check-udp-gro-forwarding \
+  | jq -rc '.Warning' \
+  | sed -nr 's/^UDP GRO forwarding is suboptimally configured on (\S+),.*$/\1/p') \
+  && bashio::var.has_value "${interface}";
+then
+  bashio::log.info "Allow UDP GRO for forwarding on ${interface}"
+  ethtool -K "${interface}" rx-udp-gro-forwarding on rx-gro-list off &> /dev/null || true
+fi
 
 # Delete previously created persistent tailscale serve configuration ONCE
 # After add-on's serve (proxy and funnel) service is a longrun service, we do not modify the serve state permanently

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -113,7 +113,6 @@ bashio::log.info "Tailscale is running"
 # Linux optimizations for subnet routers and exit nodes
 # Based on: https://tailscale.com/kb/1320/performance-best-practices#linux-optimizations-for-subnet-routers-and-exit-nodes
 # Note: Changes made via ethtool are not persistent and will be lost after the machine shuts down
-# Note: Everything fails silently, we do a best effort only
 if interface=$( \
   curl -sf --unix-socket /var/run/tailscale/tailscaled.sock http://local-tailscaled.sock/localapi/v0/check-udp-gro-forwarding \
   | jq -rc '.Warning' \

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -120,8 +120,10 @@ if interface=$( \
   | sed -nr 's/^UDP GRO forwarding is suboptimally configured on (\S+),.*$/\1/p') \
   && bashio::var.has_value "${interface}";
 then
-  bashio::log.info "Allow UDP GRO for forwarding on ${interface}"
-  ethtool -K "${interface}" rx-udp-gro-forwarding on rx-gro-list off &> /dev/null || true
+  bashio::log.info "Enabling UDP GRO for forwarding on ${interface}"
+  if ! ethtool -K "${interface}" rx-udp-gro-forwarding on rx-gro-list off; then
+    bashio::log.warning "Enabling UDP GRO failed"
+  fi
 fi
 
 # Delete previously created persistent tailscale serve configuration ONCE

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -113,7 +113,7 @@ bashio::log.info "Tailscale is running"
 # Linux optimizations for subnet routers and exit nodes
 # Based on: https://tailscale.com/kb/1320/performance-best-practices#linux-optimizations-for-subnet-routers-and-exit-nodes
 # Note: Changes made via ethtool are not persistent and will be lost after the machine shuts down
-# Note: Everything fails silently, we do a best effort only.
+# Note: Everything fails silently, we do a best effort only
 if interface=$( \
   curl -sf --unix-socket /var/run/tailscale/tailscaled.sock http://local-tailscaled.sock/localapi/v0/check-udp-gro-forwarding \
   | jq -rc '.Warning' \


### PR DESCRIPTION
# Proposed Changes

Revert this suggested optimization altogether, makes more problem then solves.

We could ask TS with this `curl --unix-socket /var/run/tailscale/tailscaled.sock http://local-tailscaled.sock/localapi/v0/check-udp-gro-forwarding`, but that is a bad idea, undocumented api, let them solve this on their own.

## Related Issues

fixes #362


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Removed the `ethtool` package from the Tailscale Docker image to streamline the installation process.

- **Refactor**
  - Simplified the `post-tailscaled/run` script by removing unnecessary declarations and Linux optimizations for subnet routers and exit nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->