### PR TITLE
Add default values to config

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -25,6 +25,22 @@ devices:
   - /dev/net/tun
 map:
   - share:rw
+options:
+  accept_dns: true
+  accept_routes: true
+  advertise_exit_node: true
+  advertise_connector: true
+  advertise_routes:
+    - "match(^(((25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\/(3[0-2]|[12]?\\d)|[a-fA-F\\d.:]+:[a-fA-F\\d.:]+\\/(12[0-8]|(1[01]|[1-9]?)\\d))$)?"
+  funnel: false
+  log_level: "info"
+  login_server: "https://controlplane.tailscale.com"
+  proxy: false
+  proxy_and_funnel_port: 443
+  snat_subnet_routes: true
+  stateful_filtering: false
+  taildrop: true
+  userspace_networking: true
 schema:
   accept_dns: bool?
   accept_routes: bool?

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -30,8 +30,6 @@ options:
   accept_routes: true
   advertise_exit_node: true
   advertise_connector: true
-  advertise_routes:
-    - "match(^(((25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\/(3[0-2]|[12]?\\d)|[a-fA-F\\d.:]+:[a-fA-F\\d.:]+\\/(12[0-8]|(1[01]|[1-9]?)\\d))$)?"
   funnel: false
   log_level: "info"
   login_server: "https://controlplane.tailscale.com"


### PR DESCRIPTION
# Proposed Changes

I would like to add the default values of the config options that are available. It allows for more easier configuration of the add-on as you see instantly what is enabled and disabled. If there are no default values all values are turned off on the configuration page which does not reflect the actual value used by the add-on. This could lead to confusion, why an option is turned on, even if the user thinks it is turned off.

## Related Issues

No related Issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for enhanced network settings, including DNS and route acceptance.
	- Added options for advertising exit nodes and specific route features, providing users greater control over their network setup.
	- Enhanced logging capabilities with adjustable log levels.
	- Expanded configurability with options for stateful filtering and userspace networking.
	- Updated schema to support new boolean options for improved configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->