### PR TITLE
expose only webhooks from funnel

### DIFF
--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -39,6 +39,7 @@ schema:
   login_server: url?
   proxy: bool?
   proxy_and_funnel_port: match(^(443|8443|10000)$)?
+  funnel_protection: bool?
   snat_subnet_routes: bool?
   stateful_filtering: bool?
   tags:

--- a/tailscale/rootfs/etc/nginx/templates/homeassistant.gtpl
+++ b/tailscale/rootfs/etc/nginx/templates/homeassistant.gtpl
@@ -1,0 +1,33 @@
+upstream homeassistant {
+    server 127.0.0.1:{{ .port }};
+}
+
+geo $tailscale_network {
+    default false;
+    proxy 127.0.0.1;
+    100.64.0.0/10 true;
+}
+
+server {
+    listen 127.0.0.1:8000 default_server;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+
+    set_real_ip_from  127.0.0.1;
+    real_ip_header    X-Forwarded-For;
+
+    location / {
+        {{ if .funnel_protection }}
+        if ( $tailscale_network = 'false') {
+            return 510 "You'll need to be on the Tailnet for access.";
+        }
+        {{ end }}
+
+        proxy_pass http://homeassistant;
+    }
+
+    location /api/webhook {
+        proxy_pass http://homeassistant;
+    }
+}

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -5,6 +5,14 @@
 # Configures NGINX for use with the Tailscale web
 # ==============================================================================
 
+
+# Funnel protection is disabled by default
+funnel_protection=false
+if bashio::config.true "funnel_protection";
+then
+  funnel_protection=true
+fi
+
 # Generate Ingress configuration
 bashio::var.json \
     interface "$(bashio::addon.ip_address)" \
@@ -12,3 +20,10 @@ bashio::var.json \
     | tempio \
         -template /etc/nginx/templates/ingress.gtpl \
         -out /etc/nginx/servers/ingress.conf
+
+bashio::var.json \
+    port "$(bashio::core.port)" \
+    funnel_protection "^${funnel_protection}" \
+    | tempio \
+        -template /etc/nginx/templates/homeassistant.gtpl \
+        -out /etc/nginx/servers/homeassistant.conf

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -9,4 +9,4 @@
 bashio::net.wait_for 25899 localhost 900
 
 bashio::log.info "Starting NGinx..."
-exec nginx
+exec nginx-debug

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/serve/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/serve/run
@@ -63,4 +63,4 @@ else
 fi
 
 # Set up serve
-exec /opt/tailscale ${tailscale_command} --https=$(bashio::config "proxy_and_funnel_port" "443") --set-path=/ "http://127.0.0.1:$(bashio::core.port)"
+exec /opt/tailscale ${tailscale_command} --https=$(bashio::config "proxy_and_funnel_port" "443") --set-path=/ "http://127.0.0.1:8000"


### PR DESCRIPTION

# Proposed Changes

This allows exposing only webhooks through the funnel and keeping the same external URL for the devices with Tailscale.

This is my first change to any hassio addon, so please bear with me :) I'm opening the PR to have a conversation and see if this is something you'd like in or I should maintain separately.

## Related Issues

Tailscale itself does not support ACL for funnel yet, so this is a workaround: 

* https://github.com/tailscale/tailscale/issues/13109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `funnel_protection` configuration option for enhanced security control.
  - Added NGINX configuration for secure access to the Home Assistant service, including IP whitelisting and webhook access.
  - Enhanced debugging capabilities with the addition of `nginx-debug`.

- **Bug Fixes**
  - Adjusted service port configuration to ensure proper communication with Home Assistant.

- **Documentation**
  - Updated configuration templates to reflect new options and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->