### PR TITLE
Update add-on docs to match updated Tailscale docs

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -281,9 +281,8 @@ When not set, this option is enabled by default.
 
 To support advanced [Site-to-site networking][tailscale_info_site_to_site] (eg.
 to traverse multiple networks), you can disable this functionality, and follow
-steps 2 and 3 as described on [Site-to-site
-networking][tailscale_info_site_to_site]. But do it only when you really
-understand why you need this.
+steps from step 3 on [Site-to-site networking][tailscale_info_site_to_site]. But
+do it only when you really understand why you need this.
 
 ### Option: `stateful_filtering`
 
@@ -324,7 +323,7 @@ instance, disable userspace networking mode, which will create a `tailscale0`
 network interface on your host.
 
 If you want to access other clients on your tailnet even from your local subnet,
-follow steps 2 and 3 as described on [Site-to-site
+follow steps from step 3 on [Site-to-site
 networking][tailscale_info_site_to_site].
 
 In case your local subnets collide with subnet routes within your tailnet, your


### PR DESCRIPTION
# Proposed Changes

TS siteto-site networking docs changed, this updates the reference to the steps in it.

## Related Issues

related #415


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and usability of the Tailscale Home Assistant Community Add-on documentation.
	- Updated instructions on `snat_subnet_routes` for advanced site-to-site networking.
	- Streamlined explanation of `userspace_networking` for better understanding of client access on the tailnet. 
	- Minor formatting and phrasing improvements for better coherence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->