### PR TITLE
Make DSCP configurable on tailscaled's network traffic

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -69,6 +69,7 @@ advertise_connector: true
 advertise_routes:
   - 192.168.1.0/24
   - fd12:3456:abcd::/64
+dscp: 52
 funnel: false
 log_level: info
 login_server: "https://controlplane.tailscale.com"
@@ -146,6 +147,15 @@ More information: [Subnet routers][tailscale_info_subnets]
 
 When not set, the add-on by default will advertise routes to your subnets on all
 supported interfaces.
+
+### Option: `dscp`
+
+This option allows you to set DSCP value on all tailscaled originated network
+traffic. This allows you to handle Tailscale's network traffic on your router
+separately from other network traffic.
+
+When not set, this option is disabled by default, ie. DSCP will be set to the
+default 0.
 
 ### Option: `funnel`
 

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -34,6 +34,7 @@ schema:
   advertise_connector: bool?
   advertise_routes:
     - "match(^(((25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\.){3}(25[0-5]|(2[0-4]|1\\d|[1-9]?)\\d)\\/(3[0-2]|[12]?\\d)|[a-fA-F\\d.:]+:[a-fA-F\\d.:]+\\/(12[0-8]|(1[01]|[1-9]?)\\d))$)?"
+  dscp: int(0,63)?
   funnel: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   login_server: url?

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
@@ -9,6 +9,26 @@ readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="tailscaled"
 
+declare tailscaled_gid
+
+# Remove DSCP setting
+for tailscaled_gid in $( \
+  iptables -t mangle -S OUTPUT \
+    | { grep -E '^-A OUTPUT -m owner --gid-owner \d* -j DSCP --set-dscp' || true ;} \
+    | sed -nr 's/^.*?--gid-owner\s(\d+)\s.*$/\1/p')
+do
+  bashio::log.info "Removing DSCP setting for tailscaled (IPv4)"
+  iptables -t mangle -D OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp $(bashio::config "dscp")
+done
+for tailscaled_gid in $( \
+  ip6tables -t mangle -S OUTPUT \
+    | { grep -E '^-A OUTPUT -m owner --gid-owner \d* -j DSCP --set-dscp' || true ;} \
+    | sed -nr 's/^.*?--gid-owner\s(\d+)\s.*$/\1/p')
+do
+  bashio::log.info "Removing DSCP setting for tailscaled (IPv6)"
+  ip6tables -t mangle -D OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp $(bashio::config "dscp")
+done
+
 bashio::log.info \
   "Service ${service} exited with code ${exit_code_service}" \
   "(by signal ${exit_code_signal})"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
@@ -9,25 +9,23 @@ readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 readonly service="tailscaled"
 
-declare tailscaled_gid
+readonly TAILSCALED_GID=51892
 
 # Remove DSCP setting
-for tailscaled_gid in $( \
+if (( 0 < $( \
   iptables -t mangle -S OUTPUT \
-    | { grep -E '^-A OUTPUT -m owner --gid-owner \d* -j DSCP --set-dscp' || true ;} \
-    | sed -nr 's/^.*?--gid-owner\s(\d+)\s.*$/\1/p')
-do
+  | { grep -Ec '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp' || true ;}) ))
+then
   bashio::log.info "Removing DSCP setting for tailscaled (IPv4)"
-  iptables -t mangle -D OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp $(bashio::config "dscp")
-done
-for tailscaled_gid in $( \
+  iptables -t mangle -D OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp")
+fi
+if (( 0 < $( \
   ip6tables -t mangle -S OUTPUT \
-    | { grep -E '^-A OUTPUT -m owner --gid-owner \d* -j DSCP --set-dscp' || true ;} \
-    | sed -nr 's/^.*?--gid-owner\s(\d+)\s.*$/\1/p')
-do
+  | { grep -Ec '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp' || true ;}) ))
+then
   bashio::log.info "Removing DSCP setting for tailscaled (IPv6)"
-  ip6tables -t mangle -D OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp $(bashio::config "dscp")
-done
+  ip6tables -t mangle -D OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp")
+fi
 
 bashio::log.info \
   "Service ${service} exited with code ${exit_code_service}" \

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/finish
@@ -14,14 +14,14 @@ readonly TAILSCALED_GID=51892
 # Remove DSCP setting
 if (( 0 < $( \
   iptables -t mangle -S OUTPUT \
-  | { grep -Ec '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp' || true ;}) ))
+  | { grep -Ec "^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp" || true ;}) ))
 then
   bashio::log.info "Removing DSCP setting for tailscaled (IPv4)"
   iptables -t mangle -D OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp")
 fi
 if (( 0 < $( \
   ip6tables -t mangle -S OUTPUT \
-  | { grep -Ec '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp' || true ;}) ))
+  | { grep -Ec "^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp" || true ;}) ))
 then
   bashio::log.info "Removing DSCP setting for tailscaled (IPv6)"
   ip6tables -t mangle -D OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp")

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -4,8 +4,11 @@
 # Home Assistant Community Add-on: Tailscale
 # Runs tailscale
 # ==============================================================================
+readonly TAILSCALED_GID=51892
+
 declare -a options
 declare udp_port
+declare tailscaled_gid
 
 bashio::log.info 'Starting Tailscale...'
 
@@ -30,15 +33,43 @@ then
   options+=(--tun=userspace-networking)
 fi
 
+# Prepare DSCP setting
+if ! bashio::config.has_value "dscp" || \
+  bashio::config.equals "dscp" 0;
+then
+  tailscaled_gid=0
+else
+  tailscaled_gid=$TAILSCALED_GID
+
+  # It is not strictly necessary to create the group for the gid, s6-setuidgid can set any arbitrary value, but at least we can identify it with a name
+  # Until processes running with root user, they won't have restrictions
+  addgroup -g $tailscaled_gid -S tailscaled || true
+  adduser root tailscaled || true
+
+  bashio::log.info "Setting DSCP for tailscaled (IPv4)"
+  if iptables -t mangle -S OUTPUT | grep -E '^-A OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp'; then
+    bashio::log.notice "  DSCP is already set for tailscaled"
+  elif ! iptables -t mangle -A OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp $(bashio::config "dscp"); then
+    bashio::log.warning "  Setting DSCP for tailscaled is unsuccessful"
+  fi
+
+  bashio::log.info "Setting DSCP for tailscaled (IPv6)"
+  if ip6tables -t mangle -S OUTPUT | grep -E '^-A OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp'; then
+    bashio::log.notice "  DSCP is already set for tailscaled"
+  elif ! ip6tables -t mangle -A OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp $(bashio::config "dscp"); then
+    bashio::log.warning "  Setting DSCP for tailscaled is unsuccessful"
+  fi
+fi
+
 # Run Tailscale
 if bashio::debug ; then
-  exec /opt/tailscaled "${options[@]}"
+  exec s6-setuidgid 0:${tailscaled_gid} /opt/tailscaled "${options[@]}"
 else
   bashio::log.notice \
     "Tailscale logs will be suppressed after 200 lines, set add-on's" \
     "configuration option 'log_level' to 'debug' to see further logs"
 
-  /opt/tailscaled "${options[@]}" 2>&1 \
+  s6-setuidgid 0:${tailscaled_gid} /opt/tailscaled "${options[@]}" 2>&1 \
     | stdbuf -i0 -oL -eL \
       sed -n -e '1,200p' \
         -e "201c[further tailscaled logs suppressed, set add-on's configuration option 'log_level' to 'debug' to see further tailscaled logs]"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -47,7 +47,6 @@ else
   adduser root tailscaled || true
 
   bashio::log.info "Setting DSCP for tailscaled (IPv4)"
-
   if (( 0 < $( \
     iptables -t mangle -S OUTPUT \
     | { grep -Ec "^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp" || true ;}) ))

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -47,14 +47,21 @@ else
   adduser root tailscaled || true
 
   bashio::log.info "Setting DSCP for tailscaled (IPv4)"
-  if iptables -t mangle -S OUTPUT | grep -E '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp'; then
+
+  if (( 0 < $( \
+    iptables -t mangle -S OUTPUT \
+    | { grep -Ec '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp' || true ;}) ))
+  then
     bashio::log.notice "  DSCP is already set for tailscaled"
   elif ! iptables -t mangle -A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp"); then
     bashio::log.warning "  Setting DSCP for tailscaled is unsuccessful"
   fi
 
   bashio::log.info "Setting DSCP for tailscaled (IPv6)"
-  if ip6tables -t mangle -S OUTPUT | grep -E '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp'; then
+  if (( 0 < $( \
+    ip6tables -t mangle -S OUTPUT \
+    | { grep -Ec '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp' || true ;}) ))
+  then
     bashio::log.notice "  DSCP is already set for tailscaled"
   elif ! ip6tables -t mangle -A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp"); then
     bashio::log.warning "  Setting DSCP for tailscaled is unsuccessful"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -50,7 +50,7 @@ else
 
   if (( 0 < $( \
     iptables -t mangle -S OUTPUT \
-    | { grep -Ec '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp' || true ;}) ))
+    | { grep -Ec "^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp" || true ;}) ))
   then
     bashio::log.notice "  DSCP is already set for tailscaled"
   elif ! iptables -t mangle -A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp"); then
@@ -60,7 +60,7 @@ else
   bashio::log.info "Setting DSCP for tailscaled (IPv6)"
   if (( 0 < $( \
     ip6tables -t mangle -S OUTPUT \
-    | { grep -Ec '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp' || true ;}) ))
+    | { grep -Ec "^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp" || true ;}) ))
   then
     bashio::log.notice "  DSCP is already set for tailscaled"
   elif ! ip6tables -t mangle -A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp"); then

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -39,24 +39,24 @@ if ! bashio::config.has_value "dscp" || \
 then
   tailscaled_gid=0
 else
-  tailscaled_gid=$TAILSCALED_GID
+  tailscaled_gid=${TAILSCALED_GID}
 
   # It is not strictly necessary to create the group for the gid, s6-setuidgid can set any arbitrary value, but at least we can identify it with a name
   # Until processes running with root user, they won't have restrictions
-  addgroup -g $tailscaled_gid -S tailscaled || true
+  addgroup -g ${TAILSCALED_GID} -S tailscaled || true
   adduser root tailscaled || true
 
   bashio::log.info "Setting DSCP for tailscaled (IPv4)"
-  if iptables -t mangle -S OUTPUT | grep -E '^-A OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp'; then
+  if iptables -t mangle -S OUTPUT | grep -E '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp'; then
     bashio::log.notice "  DSCP is already set for tailscaled"
-  elif ! iptables -t mangle -A OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp $(bashio::config "dscp"); then
+  elif ! iptables -t mangle -A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp"); then
     bashio::log.warning "  Setting DSCP for tailscaled is unsuccessful"
   fi
 
   bashio::log.info "Setting DSCP for tailscaled (IPv6)"
-  if ip6tables -t mangle -S OUTPUT | grep -E '^-A OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp'; then
+  if ip6tables -t mangle -S OUTPUT | grep -E '^-A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp'; then
     bashio::log.notice "  DSCP is already set for tailscaled"
-  elif ! ip6tables -t mangle -A OUTPUT -m owner --gid-owner $tailscaled_gid -j DSCP --set-dscp $(bashio::config "dscp"); then
+  elif ! ip6tables -t mangle -A OUTPUT -m owner --gid-owner ${TAILSCALED_GID} -j DSCP --set-dscp $(bashio::config "dscp"); then
     bashio::log.warning "  Setting DSCP for tailscaled is unsuccessful"
   fi
 fi

--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -34,6 +34,14 @@ configuration:
       your device is connected to) to other clients on your tailnet.
       When not set, the add-on by default will advertise routes to your subnets on all
       supported interfaces.
+  dscp:
+    name: DSCP
+    description: >-
+      This option allows you to set DSCP value on all tailscaled originated network
+      traffic. This allows you to handle Tailscale's network traffic on your router
+      separately from other network traffic.
+      When not set, this option is disabled by default, ie. DSCP will be set to the
+      default 0.
   funnel:
     name: Tailscale Funnel
     description: >-


### PR DESCRIPTION
# Proposed Changes

It is practical if someone want's to handle TS's connection differently on his/her router. TS's packages are coming from the same IP like any other HA traffic, I couldn't find any other way to distinguish it from other HA traffic.

My use-case: only TS is allowed to use the backup WAN connection, it keeps HA's UI available, but all other traffic can be dropped until the main WAN recovers.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new configuration option, `dscp`, allowing users to set Differentiated Services Code Point (DSCP) values for Tailscale network traffic.
  
- **Documentation**
  - Updated documentation to include the new `dscp` configuration option and clarified existing configuration instructions.

These enhancements improve user control over network traffic management, ensuring a more tailored experience with Tailscale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->