### PR TITLE
Make log timestamp format for the add-on identical with Tailscale's format

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -35,8 +35,13 @@ RUN \
 # Copy root filesystem
 COPY rootfs /
 
-# S6 Overlay stage 2 hook
-ENV S6_STAGE2_HOOK=/etc/s6-overlay/scripts/stage2_hook.sh
+# Environment variables
+ENV \
+    # S6 Overlay stage 2 hook
+    S6_STAGE2_HOOK=/etc/s6-overlay/scripts/stage2_hook.sh \
+    # Add-on log format
+    LOG_FORMAT="{TIMESTAMP} {LEVEL}: {MESSAGE}" \
+    LOG_TIMESTAMP="%Y/%m/%d %H:%M:%S"
 
 # Build arguments
 ARG BUILD_ARCH


### PR DESCRIPTION
# Proposed Changes

It just looks better.

And if TS logs suppressed after 200 lines, without this, we don't have date in the log messages.

Old:

```
2024/11/14 22:14:33 wgengine: Reconfig: configuring userspace WireGuard config (with 0/9 peers)
[22:14:33] INFO: Starting NGinx...
2024/11/14 22:14:33 wgengine: Reconfig: configuring router
```

New:
```
2024/11/15 16:27:37 web server running on: http://127.0.0.1:25897
2024/11/15 16:27:37 INFO: Starting NGinx...
2024/11/15 16:27:37 control: doLogin(regen=false, hasUrl=false)
```

## Related Issues
