### PR TITLE
Fix base image update

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -16,7 +16,7 @@ RUN \
         iptables=1.8.10-r5 \
         nginx=1.26.2-r3 \
         coreutils=9.5-r1 \
-        networkmanager-cli=1.50.0-r3 \
+        networkmanager=1.50.0-r3 \
     \
     && ln -sf /sbin/xtables-nft-multi /sbin/ip6tables \
     && ln -sf /sbin/xtables-nft-multi /sbin/iptables \


### PR DESCRIPTION
# Proposed Changes

/usr/libexec/nm-dispatcher is moved from networkmanager-common to networkmanager, not networkmanager-cli

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the NetworkManager package to the full version for improved functionality.
- **Bug Fixes**
	- Resolved issues related to the previous command-line interface version of NetworkManager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->