### PR TITLE
Don't break sentences into multiple log messages

### DIFF
--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -15,8 +15,9 @@ readarray -t routes < <(subnet-routes advertised)
 # If user later enables subnet routing for site-to-site networking, these settings are already there
 # Source: https://tailscale.com/kb/1214/site-to-site/ Step 1 / Point 4
 if (( 0 < ${#routes[@]} )); then
-  bashio::log.info "Clamping the MSS to the MTU for all advertised subnet's interface,"
-  bashio::log.info "to support site-to-site networking better"
+  bashio::log.info \
+    "Clamping the MSS to the MTU for all advertised subnet's interface," \
+    "to support site-to-site networking better"
 
   # Find interfaces for subnet routes
   for route in "${routes[@]}"; do

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -15,9 +15,8 @@ readarray -t routes < <(subnet-routes advertised)
 # If user later enables subnet routing for site-to-site networking, these settings are already there
 # Source: https://tailscale.com/kb/1214/site-to-site/ Step 1 / Point 4
 if (( 0 < ${#routes[@]} )); then
-  bashio::log.info \
-    "Clamping the MSS to the MTU for all advertised subnet's interface," \
-    "to support site-to-site networking better"
+  bashio::log.info "Clamping the MSS to the MTU for all advertised subnet's interface,"
+  bashio::log.info "to support site-to-site networking better"
 
   # Find interfaces for subnet routes
   for route in "${routes[@]}"; do

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/post-tailscaled/run
@@ -155,10 +155,12 @@ then
         | jq -rc '.Peer[] | select(has("PrimaryRoutes")) | .PrimaryRoutes[]' \
         | sort -u))
   if (( 0 < ${#colliding_routes[@]} )); then
-    bashio::log.warning "Currently the following subnets are both present as local subnets"
-    bashio::log.warning "and are also routed within your tailnet to other nodes!"
-    bashio::log.warning "Please reconfigure your subnet routing within your tailnet"
-    bashio::log.warning "to prevent current or future collisions."
+    bashio::log.warning \
+      "Currently the following subnets are both present as local subnets" \
+      "and are also routed within your tailnet to other nodes!"
+    bashio::log.warning \
+      "Please reconfigure your subnet routing within your tailnet" \
+      "to prevent current or future collisions."
   fi
   for route in "${colliding_routes[@]}"; do
     bashio::log.warning "  ${route}"
@@ -169,8 +171,11 @@ fi
 if ! bashio::config.has_value "userspace_networking" || \
   bashio::config.true "userspace_networking";
 then
-  bashio::log.notice "The add-on uses userspace networking mode."
-  bashio::log.notice "If you need to access other clients on your tailnet from your Home Assistant instance,"
-  bashio::log.notice "disable userspace networking mode, that will create a \"tailscale0\" network interface on your host."
-  bashio::log.notice "Please check your configuration based on the add-on's documentation under \"Option: userspace_networking\""
+  bashio::log.notice \
+    "The add-on uses userspace networking mode."
+  bashio::log.notice \
+    "If you need to access other clients on your tailnet from your Home Assistant instance," \
+    "disable userspace networking mode, that will create a \"tailscale0\" network interface on your host."
+  bashio::log.notice \
+    "Please check your configuration based on the add-on's documentation under \"Option: userspace_networking\""
 fi

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -31,15 +31,17 @@ then
   fi
 
   readarray -t routes < <(subnet-routes local)
-  bashio::log.info "Adding local subnets to ip rules with higher priority than Tailscale's routing,"
-  bashio::log.info "to prevent routing local subnets if the same subnet is routed within your tailnet."
+  bashio::log.info \
+    "Adding local subnets to ip rules with higher priority than Tailscale's routing," \
+    "to prevent routing local subnets if the same subnet is routed within your tailnet."
   if (( 0 == ${#routes[@]} )); then
     # Do not remove this warning, usually this is superfluous,
     # but I've run into situation where Supervisor needed a restart to return valid interface address data
     # (that seems to be a hard to reproduce bug, better have some log in the future than not).
     # See: https://github.com/home-assistant/supervisor/issues/5361
-    bashio::log.warning "  There are no local subnets to protect!"
-    bashio::log.warning "  Maybe this is a temporary situation due to configuration change underway."
+    bashio::log.warning \
+      "  There are no local subnets to protect!" \
+      "Maybe this is a temporary situation due to configuration change underway."
   else
     for route in "${routes[@]}"; do
       if [[ "${route}" =~ .*:.* ]]; then


### PR DESCRIPTION
# Proposed Changes

Just cosmetics, to prevent Tailscale inserting logs in the middle of the sentence, like this:

```
2025/01/19 00:18:20 INFO: Adding local subnets to ip rules with higher priority than Tailscale's routing,
2025/01/19 00:18:20 You have disabled logging. Tailscale will not be able to provide support.
2025/01/19 00:18:20 INFO: to prevent routing local subnets if the same subnet is routed within your tailnet.
```

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved log message formatting in Tailscale scripts
	- Enhanced readability of warning and notice log messages
	- Restructured multi-line logging statements without changing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->