### PR TITLE
Fix MSS clamping for site-to-site networking

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -281,9 +281,8 @@ When not set, this option is enabled by default.
 
 To support advanced [Site-to-site networking][tailscale_info_site_to_site] (eg.
 to traverse multiple networks), you can disable this functionality, and follow
-steps on [Site-to-site networking][tailscale_info_site_to_site] (Note: "IP
-address forwarding" and "Clamp the MSS to the MTU" is already done by the
-add-on). But do it only when you really understand why you need this.
+steps from step 3 on [Site-to-site networking][tailscale_info_site_to_site]. But
+do it only when you really understand why you need this.
 
 ### Option: `stateful_filtering`
 
@@ -326,9 +325,8 @@ with their tailnet IP, but with their tailnet name, you have to configure Home
 Assistant's DNS options also.
 
 If you want to access other clients on your tailnet even from your local subnet,
-follow steps on [Site-to-site networking][tailscale_info_site_to_site] (Note:
-"IP address forwarding" and "Clamp the MSS to the MTU" is already done by the
-add-on).
+follow steps from step 3 on [Site-to-site
+networking][tailscale_info_site_to_site].
 
 In case your local subnets collide with subnet routes within your tailnet, your
 local network access has priority, and these addresses won't be routed toward

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -281,8 +281,9 @@ When not set, this option is enabled by default.
 
 To support advanced [Site-to-site networking][tailscale_info_site_to_site] (eg.
 to traverse multiple networks), you can disable this functionality, and follow
-steps from step 3 on [Site-to-site networking][tailscale_info_site_to_site]. But
-do it only when you really understand why you need this.
+steps on [Site-to-site networking][tailscale_info_site_to_site] (Note: "IP
+address forwarding" and "Clamp the MSS to the MTU" is already done by the
+add-on). But do it only when you really understand why you need this.
 
 ### Option: `stateful_filtering`
 
@@ -325,8 +326,9 @@ with their tailnet IP, but with their tailnet name, you have to configure Home
 Assistant's DNS options also.
 
 If you want to access other clients on your tailnet even from your local subnet,
-follow steps from step 3 on [Site-to-site
-networking][tailscale_info_site_to_site].
+follow steps on [Site-to-site networking][tailscale_info_site_to_site] (Note:
+"IP address forwarding" and "Clamp the MSS to the MTU" is already done by the
+add-on).
 
 In case your local subnets collide with subnet routes within your tailnet, your
 local network access has priority, and these addresses won't be routed toward

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
@@ -5,7 +5,6 @@
 # Remove the MSS clamping
 # ==============================================================================
 
-readonly TAILSCALE_INTERFACE="tailscale0"
 readonly CLAMPING_IPTABLES_OPTIONS="-p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
 
 declare interface
@@ -13,17 +12,21 @@ declare interface
 # In case of non userspace networking, remove the MSS clamping for all advertised subnet's interface
 for interface in $( \
   iptables -t mangle -S FORWARD \
-  | { grep -E "^-A FORWARD -i tailscale\d -o \S+ ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
+  | { grep -E "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
   | sed -nr 's/^.*?-o\s(\S+)\s.*$/\1/p')
 do
   bashio::log.info "Removing the MSS clamping for interface ${interface} (IPv4)"
-  iptables -t mangle -D FORWARD -i ${TAILSCALE_INTERFACE} -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}
+  if ! iptables -t mangle -D FORWARD -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
+    bashio::log.warning "Removing clamping is unsuccessful"
+  fi
 done
 for interface in $( \
   ip6tables -t mangle -S FORWARD \
-  | { grep -E "^-A FORWARD -i tailscale\d -o \S+ ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
+  | { grep -E "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
   | sed -nr 's/^.*?-o\s(\S+)\s.*$/\1/p')
 do
   bashio::log.info "Removing the MSS clamping for interface ${interface} (IPv6)"
-  ip6tables -t mangle -D FORWARD -i ${TAILSCALE_INTERFACE} -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}
+  if ! ip6tables -t mangle -D FORWARD -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
+    bashio::log.warning "Removing clamping is unsuccessful"
+  fi
 done

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
@@ -5,22 +5,25 @@
 # Remove the MSS clamping
 # ==============================================================================
 
+readonly TAILSCALE_INTERFACE="tailscale0"
+readonly CLAMPING_IPTABLES_OPTIONS="-p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
+
 declare interface
 
 # In case of non userspace networking, remove the MSS clamping for all advertised subnet's interface
 for interface in $( \
   iptables -t mangle -S FORWARD \
-  | { grep -E '^-A FORWARD -i tailscale\d' || true ;} \
-  | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p')
+  | { grep -E "^-A FORWARD -i tailscale\d -o \S+ ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
+  | sed -nr 's/^.*?-o\s(\S+)\s.*$/\1/p')
 do
   bashio::log.info "Removing the MSS clamping for interface ${interface} (IPv4)"
-  iptables -t mangle -D FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+  iptables -t mangle -D FORWARD -i ${TAILSCALE_INTERFACE} -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}
 done
 for interface in $( \
   ip6tables -t mangle -S FORWARD \
-  | { grep -E '^-A FORWARD -i tailscale\d' || true ;} \
-  | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p')
+  | { grep -E "^-A FORWARD -i tailscale\d -o \S+ ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
+  | sed -nr 's/^.*?-o\s(\S+)\s.*$/\1/p')
 do
   bashio::log.info "Removing the MSS clamping for interface ${interface} (IPv6)"
-  ip6tables -t mangle -D FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+  ip6tables -t mangle -D FORWARD -i ${TAILSCALE_INTERFACE} -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}
 done

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/finish
@@ -7,26 +7,23 @@
 
 readonly CLAMPING_IPTABLES_OPTIONS="-p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
 
-declare interface
-
 # In case of non userspace networking, remove the MSS clamping for all advertised subnet's interface
-for interface in $( \
-  iptables -t mangle -S FORWARD \
-  | { grep -E "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
-  | sed -nr 's/^.*?-o\s(\S+)\s.*$/\1/p')
-do
-  bashio::log.info "Removing the MSS clamping for interface ${interface} (IPv4)"
-  if ! iptables -t mangle -D FORWARD -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
-    bashio::log.warning "Removing clamping is unsuccessful"
-  fi
-done
-for interface in $( \
-  ip6tables -t mangle -S FORWARD \
-  | { grep -E "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
-  | sed -nr 's/^.*?-o\s(\S+)\s.*$/\1/p')
-do
-  bashio::log.info "Removing the MSS clamping for interface ${interface} (IPv6)"
-  if ! ip6tables -t mangle -D FORWARD -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
-    bashio::log.warning "Removing clamping is unsuccessful"
-  fi
-done
+function remove_clamping() {
+  local cmd="$1"
+  local ip_version="$2"
+  local interface
+
+  for interface in $( \
+    ${cmd} -t mangle -S FORWARD \
+    | { grep -E "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$" || true ;} \
+    | sed -nr 's/^.*?-o\s(\S+)\s.*$/\1/p')
+  do
+    bashio::log.info "Removing the MSS clamping for interface ${interface} (${ip_version})"
+    if ! ${cmd} -t mangle -D FORWARD -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
+      bashio::log.warning "Removing clamping is unsuccessful (${ip_version})"
+    fi
+  done
+}
+
+remove_clamping "iptables" "IPv4"
+remove_clamping "ip6tables" "IPv6"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -11,25 +11,22 @@ readonly CLAMPING_IPTABLES_OPTIONS="-p tcp -m tcp --tcp-flags SYN,RST SYN -j TCP
 # In case of non userspace networking, clamp the MSS to the MTU for tailscale's interface
 # If user later enables subnet routing for site-to-site networking, this config is already there
 # Source: https://tailscale.com/kb/1214/site-to-site/
-bashio::log.info "Clamping the MSS to the MTU for interface ${TAILSCALE_INTERFACE}," \
-  "to support site-to-site networking better (IPv4)"
-if iptables -t mangle -S FORWARD \
-  | grep -Eq "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$"
-then
-  bashio::log.notice "Clamping is already set"
-else
-  if ! iptables -t mangle -A FORWARD -o ${TAILSCALE_INTERFACE} ${CLAMPING_IPTABLES_OPTIONS}; then
-    bashio::log.warning "Setting up clamping is unsuccessful"
+function setup_clamping() {
+  local cmd="$1"
+  local ip_version="$2"
+
+  bashio::log.info "Clamping the MSS to the MTU for interface ${TAILSCALE_INTERFACE}," \
+    "to support site-to-site networking better (${ip_version})"
+  if ${cmd} -t mangle -S FORWARD \
+    | grep -Eq "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$"
+  then
+    bashio::log.notice "Clamping is already set (${ip_version})"
+  else
+    if ! ${cmd} -t mangle -A FORWARD -o ${TAILSCALE_INTERFACE} ${CLAMPING_IPTABLES_OPTIONS}; then
+      bashio::log.warning "Setting up clamping is unsuccessful (${ip_version})"
+    fi
   fi
-fi
-bashio::log.info "Clamping the MSS to the MTU for interface ${TAILSCALE_INTERFACE}," \
-  "to support site-to-site networking better (IPv6)"
-if ip6tables -t mangle -S FORWARD \
-  | grep -Eq "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$"
-then
-  bashio::log.notice "Clamping is already set"
-else
-  if ! ip6tables -t mangle -A FORWARD -o ${TAILSCALE_INTERFACE} ${CLAMPING_IPTABLES_OPTIONS}; then
-    bashio::log.warning "Setting up clamping is unsuccessful"
-  fi
-fi
+}
+
+setup_clamping "iptables" "IPv4"
+setup_clamping "ip6tables" "IPv6"

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -5,6 +5,9 @@
 # Clamp the MSS to the MTU
 # ==============================================================================
 
+readonly TAILSCALE_INTERFACE="tailscale0"
+readonly CLAMPING_IPTABLES_OPTIONS="-p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
+
 declare -a routes=()
 declare -a interfaces=()
 declare route family interface
@@ -13,7 +16,7 @@ readarray -t routes < <(subnet-routes advertised)
 
 # In case of non userspace networking, clamp the MSS to the MTU for all advertised subnet's interface
 # If user later enables subnet routing for site-to-site networking, these settings are already there
-# Source: https://tailscale.com/kb/1214/site-to-site/ Step 1 / Point 4
+# Source: https://tailscale.com/kb/1214/site-to-site/
 if (( 0 < ${#routes[@]} )); then
   bashio::log.info "Clamping the MSS to the MTU for all advertised subnet's interface,"
   bashio::log.info "to support site-to-site networking better"
@@ -38,25 +41,23 @@ if (( 0 < ${#routes[@]} )); then
 
   for interface in "${interfaces[@]}"; do
     bashio::log.info "  Clamping the MSS for interface ${interface} (IPv4)"
-    if [[ "${interface}" == $(iptables -t mangle -S FORWARD \
-      | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
-      | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
+    if iptables -t mangle -S FORWARD \
+      | grep -Eq "^-A FORWARD -i tailscale\d -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}$"
     then
       bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv4)"
     else
-      if ! iptables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu; then
+      if ! iptables -t mangle -A FORWARD -i ${TAILSCALE_INTERFACE} -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
         bashio::log.warning "Altering the MSS for site-to-site networking is unsuccessful"
         break
       fi
     fi
     bashio::log.info "  Clamping the MSS for interface ${interface} (IPv6)"
-    if [[ "${interface}" == $(ip6tables -t mangle -S FORWARD \
-      | { grep -E "^-A FORWARD -i tailscale\d -o ${interface}" || true ;} \
-      | sed -nr 's/^.*?-o\s([A-Za-z0-9]+)\s.*$/\1/p') ]]
+    if ip6tables -t mangle -S FORWARD \
+      | grep -Eq "^-A FORWARD -i tailscale\d -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}$"
     then
       bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv6)"
     else
-      if ! ip6tables -t mangle -A FORWARD -i tailscale0 -o ${interface} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu; then
+      if ! ip6tables -t mangle -A FORWARD -i ${TAILSCALE_INTERFACE} -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
         bashio::log.warning "Altering the MSS for site-to-site networking is unsuccessful"
         break
       fi

--- a/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
+++ b/tailscale/rootfs/etc/s6-overlay/s6-rc.d/mss-clamping/run
@@ -8,59 +8,28 @@
 readonly TAILSCALE_INTERFACE="tailscale0"
 readonly CLAMPING_IPTABLES_OPTIONS="-p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
 
-declare -a routes=()
-declare -a interfaces=()
-declare route family interface
-
-readarray -t routes < <(subnet-routes advertised)
-
-# In case of non userspace networking, clamp the MSS to the MTU for all advertised subnet's interface
-# If user later enables subnet routing for site-to-site networking, these settings are already there
+# In case of non userspace networking, clamp the MSS to the MTU for tailscale's interface
+# If user later enables subnet routing for site-to-site networking, this config is already there
 # Source: https://tailscale.com/kb/1214/site-to-site/
-if (( 0 < ${#routes[@]} )); then
-  bashio::log.info "Clamping the MSS to the MTU for all advertised subnet's interface,"
-  bashio::log.info "to support site-to-site networking better"
-
-  # Find interfaces for subnet routes
-  for route in "${routes[@]}"; do
-    if [[ "${route}" =~ .*:.* ]]; then
-      family="-6"
-    else
-      family="-4"
-    fi
-    for interface in $( \
-      ip "${family}" -json route show to match "${route}" \
-      | jq --raw-output -c -M '.[].dev')
-    do
-      interfaces+=("${interface}")
-    done
-  done
-
-  # Remove duplicate entries
-  readarray -t interfaces < <(printf "%s" "${interfaces[@]/%/$'\n'}" | sort -u)
-
-  for interface in "${interfaces[@]}"; do
-    bashio::log.info "  Clamping the MSS for interface ${interface} (IPv4)"
-    if iptables -t mangle -S FORWARD \
-      | grep -Eq "^-A FORWARD -i tailscale\d -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}$"
-    then
-      bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv4)"
-    else
-      if ! iptables -t mangle -A FORWARD -i ${TAILSCALE_INTERFACE} -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
-        bashio::log.warning "Altering the MSS for site-to-site networking is unsuccessful"
-        break
-      fi
-    fi
-    bashio::log.info "  Clamping the MSS for interface ${interface} (IPv6)"
-    if ip6tables -t mangle -S FORWARD \
-      | grep -Eq "^-A FORWARD -i tailscale\d -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}$"
-    then
-      bashio::log.notice "  MSS is already clamped for interface ${interface} (IPv6)"
-    else
-      if ! ip6tables -t mangle -A FORWARD -i ${TAILSCALE_INTERFACE} -o ${interface} ${CLAMPING_IPTABLES_OPTIONS}; then
-        bashio::log.warning "Altering the MSS for site-to-site networking is unsuccessful"
-        break
-      fi
-    fi
-  done
+bashio::log.info "Clamping the MSS to the MTU for interface ${TAILSCALE_INTERFACE}," \
+  "to support site-to-site networking better (IPv4)"
+if iptables -t mangle -S FORWARD \
+  | grep -Eq "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$"
+then
+  bashio::log.notice "Clamping is already set"
+else
+  if ! iptables -t mangle -A FORWARD -o ${TAILSCALE_INTERFACE} ${CLAMPING_IPTABLES_OPTIONS}; then
+    bashio::log.warning "Setting up clamping is unsuccessful"
+  fi
+fi
+bashio::log.info "Clamping the MSS to the MTU for interface ${TAILSCALE_INTERFACE}," \
+  "to support site-to-site networking better (IPv6)"
+if ip6tables -t mangle -S FORWARD \
+  | grep -Eq "^-A FORWARD -o tailscale\d ${CLAMPING_IPTABLES_OPTIONS}$"
+then
+  bashio::log.notice "Clamping is already set"
+else
+  if ! ip6tables -t mangle -A FORWARD -o ${TAILSCALE_INTERFACE} ${CLAMPING_IPTABLES_OPTIONS}; then
+    bashio::log.warning "Setting up clamping is unsuccessful"
+  fi
 fi


### PR DESCRIPTION
# Proposed Changes

TS docs got updated, doc was wrong, showed the exact opposite where should this be applied (incoming or outgoing traffic on tailscale0 interface).

Currently the docs are equal with the real code in TS-s docker image ([here](https://github.com/tailscale/tailscale/blob/v1.78.1/util/linuxfw/iptables_runner.go#L441)).

This PR follows the new TS doc.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved MSS clamping script for Tailscale interface.
	- Enhanced error handling for iptables rule management.
	- Simplified network configuration logic focusing on the `tailscale0` interface.
	- Streamlined interface-specific network setup process. 
	- Introduced constants for interface and iptables options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->