### PR TITLE
Update documentation about UI bug in configuration editor - or make all the config options mandatory

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -89,17 +89,17 @@ userspace_networking: true
 > optional configuration options" switch on the Configuration tab!
 
 > [!CAUTION]
-> When you want to change the default behaviour of any of these optional
-> configuration options, **add them to the YAML add-on configuration manually**,
-> by using the "Edit in YAML" in the ... menu on the right and save them! Use
-> the UI to edit them only after you added them manually!
+> When you want to change the default behaviour of these optional configuration
+> options, **add them to the YAML add-on configuration manually**, by using the
+> "Edit in YAML" in the ... menu on the right and save them! Use the UI to edit
+> them only after you added them manually!
 
 > [!WARNING]
 > Home Assistant's UI will show you all the optional configuration options
-> turned off instead of grayed out, and you will falsely believe that those are
-> the values that will be stored, so you will enable options, that by default
-> are already enabled when unused, and you will let options be disabled, that
-> you originally wanted to disable, but the **UI will not add these disabled
+> turned off instead of grayed out. You will falsely believe that those are the
+> values that will be stored, so you will enable options, that by default are
+> already enabled when unused, and you will let options be disabled, that you
+> originally wanted to disable. But the **UI will not add these disabled
 > optional configuration options** to the YAML add-on configuration, and at the
 > end nothing will change in the add-on's functionality after a restart!
 

--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -84,6 +84,25 @@ userspace_networking: true
 > change them through the Web UI, because all the changes made there would be
 > lost when the add-on is restarted.
 
+> [!CAUTION]
+> Due to limitations in Home Assistant's UI, **do not use** the "Show unused
+> optional configuration options" switch on the Configuration tab!
+
+> [!CAUTION]
+> When you want to change the default behaviour of any of these optional
+> configuration options, **add them to the YAML add-on configuration manually**,
+> by using the "Edit in YAML" in the ... menu on the right and save them! Use
+> the UI to edit them only after you added them manually!
+
+> [!WARNING]
+> Home Assistant's UI will show you all the optional configuration options
+> turned off instead of grayed out, and you will falsely believe that those are
+> the values that will be stored, so you will enable options, that by default
+> are already enabled when unused, and you will let options be disabled, that
+> you originally wanted to disable, but the **UI will not add these disabled
+> optional configuration options** to the YAML add-on configuration, and at the
+> end nothing will change in the add-on's functionality after a restart!
+
 ### Option: `accept_dns`
 
 If you are experiencing trouble with MagicDNS on this device and wish to


### PR DESCRIPTION
# Proposed Changes

This issue is much more serious than it seems, users always show configurations where most of the default enabled options are enabled manually, and complain that disabled options are not working or hard to make them to work.

They waste hours on forums and debugging a configuration issue caused by a very misleading UI config editor!

## Related Issues

fixes #462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Enhanced guidance for configuring the Tailscale add-on.
	- Added cautionary notes to help users avoid configuration pitfalls with the Home Assistant UI.
		- Advises against using the "Show unused optional configuration options" switch to prevent confusion.
		- Emphasizes the necessity of manually updating optional settings via YAML for accurate configuration.
		- Warns that the UI may misrepresent the state of optional configuration options, leading to potential misunderstandings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->