### PR TITLE
Reformat docs about read-only Web-UI

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -56,11 +56,6 @@ supported interfaces to Tailscale.
 Consider disabling key expiry to avoid losing connection to your Home Assistant
 device. See [Key expiry][tailscale_info_key_expiry] for more information.
 
-**Note:** _Some of the options below also available on Tailscale's web interface
-through the Web UI, but they are made read only there. You can't change them
-through the Web UI, because all the changes made there would be lost when the
-add-on is restarted._
-
 ```yaml
 accept_dns: true
 accept_routes: true
@@ -82,6 +77,12 @@ tags:
 taildrop: true
 userspace_networking: true
 ```
+
+> [!NOTE]
+> Some of the configuration options are also available on Tailscale's web
+> interface through the Web UI, but they are made read only there. You can't
+> change them through the Web UI, because all the changes made there would be
+> lost when the add-on is restarted.
 
 ### Option: `accept_dns`
 


### PR DESCRIPTION
# Proposed Changes

Just follows the formatting style of #463

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the add-on documentation to clearly explain that certain configuration options available via the web interface are read-only, with changes not persisting after a restart.
	- Reorganized and reformatted the advisory note for improved clarity and user awareness of these limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->