### PR TITLE
Skip DHCP lease renewal in subnet protection service if nothing has changed

### DIFF
--- a/tailscale/rootfs/etc/NetworkManager/dispatcher.d/protect-subnets
+++ b/tailscale/rootfs/etc/NetworkManager/dispatcher.d/protect-subnets
@@ -2,15 +2,30 @@
 # shellcheck shell=bash
 # The shebang 'with-contenv-merge' above is identical with 'with-contenv', but doesn't clear the current environment containing the dispatcher variables
 
+function halt-add-on() {
+  bashio::log.error "Failed to protect subnet routes. Halting add-on to prevent network loss."
+  echo -n 1 > /run/s6-linux-init-container-results/exitcode
+  exec /run/s6/basedir/bin/halt
+}
+
 case "${NM_DISPATCHER_ACTION}" in
-  up|down|dhcp4-change|dhcp6-change)
+  up|down)
     bashio::log.info "Handling Network Manager action ${DEVICE_IP_IFACE-} ${NM_DISPATCHER_ACTION}"
     unprotect-subnet-routes
     if ! protect-subnet-routes; then
       # Better stop add-on than risking losing all network connections
-      bashio::log.error "Failed to protect subnet routes. Halting add-on to prevent network loss."
-      echo -n 1 > /run/s6-linux-init-container-results/exitcode
-      exec /run/s6/basedir/bin/halt
+      halt-add-on
+    fi
+    ;;
+  dhcp4-change|dhcp6-change)
+    # Do anything only when the addresses are really changed
+    if [[ "$(unprotect-subnet-routes test)" != "$(protect-subnet-routes test)" ]]; then
+      bashio::log.info "Handling Network Manager action ${DEVICE_IP_IFACE-} ${NM_DISPATCHER_ACTION}"
+      unprotect-subnet-routes
+      if ! protect-subnet-routes tested; then
+        # Better stop add-on than risking losing all network connections
+        halt-add-on
+      fi
     fi
     ;;
   connectivity-change)

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -29,8 +29,7 @@ then
     # So we wait a little
     while ! bashio::api.supervisor GET "/addons/self/options/config" false &> /dev/null; do
       if (( wait_counter++ == $WAIT_COUNT )); then
-        bashio::log.error "Supervisor is unreachable"
-        bashio::exit.nok
+        bashio::exit.nok "Supervisor is unreachable"
       fi
       bashio::log.info "Waiting for the supervisor to be ready..."
       sleep $WAIT_DELAY
@@ -66,7 +65,7 @@ then
         if ! response=$(ip "${family}" rule add to "${route}" priority ${PROTECTION_RULE_PRIORITY} table main 2>&1); then
           if [[ "${response}" != "RTNETLINK answers: File exists" ]]; then
             echo "${response}"
-            bashio::exit.nok
+            bashio::exit.nok "  Adding route ${route} to ip rules is unsuccessful"
           else
             bashio::log.notice "  Route ${route} is already added to ip rules"
           fi

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -27,7 +27,7 @@ then
     bashio::cache.flush_all
     # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
     # So we wait a little
-    while ! bashio::api.supervisor GET "/addons/self/options/config" false &> /dev/null; do
+    while ! bashio::api.supervisor GET "/network/interface/default/info" false &> /dev/null; do
       if (( wait_counter++ == $WAIT_COUNT )); then
         bashio::exit.nok "Supervisor is unreachable"
       fi

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -42,7 +42,7 @@ then
 
   readarray -t routes < <(subnet-routes local)
   if [[ "${1-}" == "test" ]]; then
-    printf "%s" "${routes[@]/%/$'\n'}"
+    printf "%s\n" "${routes[@]}"
   else
     bashio::log.info \
       "Adding local subnets to ip rules with higher priority than Tailscale's routing," \

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -14,50 +14,61 @@ declare wait_counter=0
 if bashio::config.false "userspace_networking" && \
   (! bashio::config.has_value "accept_routes" || bashio::config.true "accept_routes")
 then
-  # If it is called after network configuration is changed, we need to drop cached network info
-  bashio::cache.flush_all
-  # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
-  # So we wait a little, 60*5s = 300s = 5m
-  while ! bashio::api.supervisor GET "/addons/self/options/config" false &> /dev/null; do
-    if (( wait_counter++ == 60 )); then
-      bashio::log.error "Supervisor is unreachable"
-      bashio::exit.nok
+  if ! [[ "${1-}" =~ ^(|test|tested)$ ]]; then
+    echo "Usage: protect-subnet-routes [test|tested]" 1>&2
+    exit 1
+  fi
+
+  if [[ "${1-}" != "tested" ]]; then
+    # If it is called after network configuration is changed, we need to drop cached network info
+    bashio::cache.flush_all
+    # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
+    # So we wait a little, 60*5s = 300s = 5m
+    while ! bashio::api.supervisor GET "/addons/self/options/config" false &> /dev/null; do
+      if (( wait_counter++ == 60 )); then
+        bashio::log.error "Supervisor is unreachable"
+        bashio::exit.nok
+      fi
+      bashio::log.info "Waiting for the supervisor to be ready..."
+      sleep 5
+    done
+    if (( wait_counter != 0 )); then
+      bashio::log.info "Supervisor is ready"
     fi
-    bashio::log.info "Waiting for the supervisor to be ready..."
-    sleep 5
-  done
-  if (( wait_counter != 0 )); then
-    bashio::log.info "Supervisor is ready"
   fi
 
   readarray -t routes < <(subnet-routes local)
-  bashio::log.info \
-    "Adding local subnets to ip rules with higher priority than Tailscale's routing," \
-    "to prevent routing local subnets if the same subnet is routed within your tailnet."
-  if (( 0 == ${#routes[@]} )); then
-    # Do not remove this warning, usually this is superfluous,
-    # but I've run into situation where Supervisor needed a restart to return valid interface address data
-    # (that seems to be a hard to reproduce bug, better have some log in the future than not).
-    # See: https://github.com/home-assistant/supervisor/issues/5361
-    bashio::log.warning \
-      "  There are no local subnets to protect!" \
-      "Maybe this is a temporary situation due to configuration change underway."
+  if [[ "${1-}" == "test" ]]; then
+    printf "%s" "${routes[@]/%/$'\n'}"
   else
-    for route in "${routes[@]}"; do
-      if [[ "${route}" =~ .*:.* ]]; then
-        family="-6"
-      else
-        family="-4"
-      fi
-      bashio::log.info "  Adding route ${route} to ip rules"
-      if ! response=$(ip "${family}" rule add to "${route}" priority ${PROTECTION_RULE_PRIORITY} table main 2>&1); then
-        if [[ "${response}" != "RTNETLINK answers: File exists" ]]; then
-          echo "${response}"
-          bashio::exit.nok
+    bashio::log.info \
+      "Adding local subnets to ip rules with higher priority than Tailscale's routing," \
+      "to prevent routing local subnets if the same subnet is routed within your tailnet."
+    if (( 0 == ${#routes[@]} )); then
+      # Do not remove this warning, usually this is superfluous,
+      # but I've run into situation where Supervisor needed a restart to return valid interface address data
+      # (that seems to be a hard to reproduce bug, better have some log in the future than not).
+      # See: https://github.com/home-assistant/supervisor/issues/5361
+      bashio::log.warning \
+        "  There are no local subnets to protect!" \
+        "Maybe this is a temporary situation due to configuration change underway."
+    else
+      for route in "${routes[@]}"; do
+        if [[ "${route}" =~ .*:.* ]]; then
+          family="-6"
         else
-          bashio::log.notice "  Route ${route} is already added to ip rules"
+          family="-4"
         fi
-      fi
-    done
+        bashio::log.info "  Adding route ${route} to ip rules"
+        if ! response=$(ip "${family}" rule add to "${route}" priority ${PROTECTION_RULE_PRIORITY} table main 2>&1); then
+          if [[ "${response}" != "RTNETLINK answers: File exists" ]]; then
+            echo "${response}"
+            bashio::exit.nok
+          else
+            bashio::log.notice "  Route ${route} is already added to ip rules"
+          fi
+        fi
+      done
+    fi
   fi
 fi

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -14,63 +14,62 @@ declare route family
 declare response
 declare wait_counter=0
 
-if bashio::config.false "userspace_networking" && \
-  (! bashio::config.has_value "accept_routes" || bashio::config.true "accept_routes")
-then
-  if ! [[ "${1-}" =~ ^(|test|tested)$ ]]; then
-    echo "Usage: $(basename "$0") [test|tested]" 1>&2
-    exit 1
-  fi
+if ! [[ "${1-}" =~ ^(|test|tested)$ ]]; then
+  echo "Usage: $(basename "$0") [test|tested]" 1>&2
+  exit 1
+fi
 
-  if [[ "${1-}" != "tested" ]]; then
-    # If it is called after network configuration is changed, we need to drop cached network info
-    bashio::cache.flush_all
-    # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
-    # So we wait a little
-    while ! bashio::api.supervisor GET "/network/interface/default/info" false &> /dev/null; do
-      if (( wait_counter++ == $WAIT_COUNT )); then
-        bashio::exit.nok "Supervisor is unreachable"
-      fi
-      bashio::log.info "Waiting for the supervisor to be ready..."
-      sleep $WAIT_DELAY
-    done
-    if (( wait_counter != 0 )); then
-      bashio::log.info "Supervisor is ready"
+if [[ "${1-}" != "tested" ]]; then
+  # If it is called after network configuration is changed, we need to drop cached network info
+  bashio::cache.flush_all
+  # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
+  # Test both networking and config Supervisor API availability, these APIs are called in subnet-routes script
+  # And wait a little on inaccessibility
+  while ! bashio::api.supervisor GET "/network/interface/default/info" false &> /dev/null || \
+    ! bashio::api.supervisor GET "/addons/self/options/config" false &> /dev/null
+  do
+    if (( wait_counter++ == $WAIT_COUNT )); then
+      bashio::exit.nok "Supervisor is unreachable"
     fi
+    bashio::log.info "Waiting for the supervisor to be ready..."
+    sleep $WAIT_DELAY
+  done
+  if (( wait_counter != 0 )); then
+    bashio::log.info "Supervisor is ready"
   fi
+fi
 
-  readarray -t routes < <(subnet-routes local)
-  if [[ "${1-}" == "test" ]]; then
-    printf "%s" "${routes[@]/%/$'\n'}"
+readarray -t routes < <(subnet-routes local)
+if [[ "${1-}" == "test" ]]; then
+  printf "%s" "${routes[@]/%/$'\n'}"
+else
+  bashio::log.info \
+    "Adding local subnets to ip rules with higher priority than Tailscale's routing," \
+    "to prevent routing local subnets if the same subnet is routed within your tailnet."
+  if (( 0 == ${#routes[@]} )); then
+    # Do not remove this warning, usually this is superfluous,
+    # but I've run into situation where Supervisor needed a restart to return valid interface address data
+    # (that seems to be a hard to reproduce bug, better have some log in the future than not).
+    # See: https://github.com/home-assistant/supervisor/issues/5361
+    bashio::log.warning \
+      "  There are no local subnets to protect!" \
+      "Maybe this is a temporary situation due to configuration change underway."
   else
-    bashio::log.info \
-      "Adding local subnets to ip rules with higher priority than Tailscale's routing," \
-      "to prevent routing local subnets if the same subnet is routed within your tailnet."
-    if (( 0 == ${#routes[@]} )); then
-      # Do not remove this warning, usually this is superfluous,
-      # but I've run into situation where Supervisor needed a restart to return valid interface address data
-      # (that seems to be a hard to reproduce bug, better have some log in the future than not).
-      # See: https://github.com/home-assistant/supervisor/issues/5361
-      bashio::log.warning \
-        "  There are no local subnets to protect!" \
-        "Maybe this is a temporary situation due to configuration change underway."
-    else
-      for route in "${routes[@]}"; do
-        if [[ "${route}" =~ .*:.* ]]; then
-          family="-6"
+    for route in "${routes[@]}"; do
+      if [[ "${route}" =~ .*:.* ]]; then
+        family="-6"
+      else
+        family="-4"
+      fi
+      bashio::log.info "  Adding route ${route} to ip rules"
+      if ! response=$(ip "${family}" rule add to "${route}" priority ${PROTECTION_RULE_PRIORITY} table main 2>&1); then
+        if [[ "${response}" != "RTNETLINK answers: File exists" ]]; then
+          echo "${response}"
+          bashio::exit.nok "  Adding route ${route} to ip rules is unsuccessful"
         else
-          family="-4"
+          bashio::log.notice "  Route ${route} is already added to ip rules"
         fi
-        bashio::log.info "  Adding route ${route} to ip rules"
-        if ! response=$(ip "${family}" rule add to "${route}" priority ${PROTECTION_RULE_PRIORITY} table main 2>&1); then
-          if [[ "${response}" != "RTNETLINK answers: File exists" ]]; then
-            echo "${response}"
-            bashio::exit.nok "  Adding route ${route} to ip rules is unsuccessful"
-          else
-            bashio::log.notice "  Route ${route} is already added to ip rules"
-          fi
-        fi
-      done
-    fi
+      fi
+    done
   fi
 fi

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -41,7 +41,7 @@ then
 
   readarray -t routes < <(subnet-routes local)
   if [[ "${1-}" == "test" ]]; then
-    printf "%s\n" "${routes[@]}"
+    printf "%s" "${routes[@]/%/$'\n'}"
   else
     bashio::log.info \
       "Adding local subnets to ip rules with higher priority than Tailscale's routing," \

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -18,7 +18,7 @@ if bashio::config.false "userspace_networking" && \
   (! bashio::config.has_value "accept_routes" || bashio::config.true "accept_routes")
 then
   if ! [[ "${1-}" =~ ^(|test|tested)$ ]]; then
-    echo "Usage: protect-subnet-routes [test|tested]" 1>&2
+    echo "Usage: $(basename "$0") [test|tested]" 1>&2
     exit 1
   fi
 

--- a/tailscale/rootfs/usr/bin/protect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/protect-subnet-routes
@@ -4,7 +4,10 @@
 # In case of non userspace networking,
 # add local subnets to ip rules with higher priority than Tailscale's routing
 # ==============================================================================
+
 readonly PROTECTION_RULE_PRIORITY=5000
+readonly WAIT_DELAY=5   # 5s
+readonly WAIT_COUNT=60  # 60*5s = 300s = 5m
 
 declare -a routes=()
 declare route family
@@ -23,14 +26,14 @@ then
     # If it is called after network configuration is changed, we need to drop cached network info
     bashio::cache.flush_all
     # It is possible to get "ERROR: Got unexpected response from the API: System is not ready with state: setup"
-    # So we wait a little, 60*5s = 300s = 5m
+    # So we wait a little
     while ! bashio::api.supervisor GET "/addons/self/options/config" false &> /dev/null; do
-      if (( wait_counter++ == 60 )); then
+      if (( wait_counter++ == $WAIT_COUNT )); then
         bashio::log.error "Supervisor is unreachable"
         bashio::exit.nok
       fi
       bashio::log.info "Waiting for the supervisor to be ready..."
-      sleep 5
+      sleep $WAIT_DELAY
     done
     if (( wait_counter != 0 )); then
       bashio::log.info "Supervisor is ready"

--- a/tailscale/rootfs/usr/bin/subnet-routes
+++ b/tailscale/rootfs/usr/bin/subnet-routes
@@ -22,7 +22,7 @@ fi
 
 if bashio::cache.exists "subnet-routes-$1"; then
   readarray -t routes < <(bashio::cache.get "subnet-routes-$1")
-  printf -v response "%s" "${routes[@]/%/$'\n'}"
+  printf -v response "%s\n" "${routes[@]}"
 else
   if [[ "$1" == "advertised" ]] && bashio::config.exists "advertise_routes"; then
     # Configuration exists, use configured values
@@ -60,9 +60,9 @@ else
   done
 
   # Remove duplicate entries
-  readarray -t routes < <(printf "%s" "${routes[@]/%/$'\n'}" | sort -u)
+  readarray -t routes < <(printf "%s\n" "${routes[@]}" | sort -u)
 
-  printf -v response "%s" "${routes[@]/%/$'\n'}"
+  printf -v response "%s\n" "${routes[@]}"
   bashio::cache.set "subnet-routes-$1" "${response}"
 fi
 

--- a/tailscale/rootfs/usr/bin/subnet-routes
+++ b/tailscale/rootfs/usr/bin/subnet-routes
@@ -22,7 +22,7 @@ fi
 
 if bashio::cache.exists "subnet-routes-$1"; then
   readarray -t routes < <(bashio::cache.get "subnet-routes-$1")
-  printf -v response "%s\n" "${routes[@]}"
+  printf -v response "%s" "${routes[@]/%/$'\n'}"
 else
   if [[ "$1" == "advertised" ]] && bashio::config.exists "advertise_routes"; then
     # Configuration exists, use configured values
@@ -60,9 +60,9 @@ else
   done
 
   # Remove duplicate entries
-  readarray -t routes < <(printf "%s\n" "${routes[@]}" | sort -u)
+  readarray -t routes < <(printf "%s" "${routes[@]/%/$'\n'}" | sort -u)
 
-  printf -v response "%s\n" "${routes[@]}"
+  printf -v response "%s" "${routes[@]/%/$'\n'}"
   bashio::cache.set "subnet-routes-$1" "${response}"
 fi
 

--- a/tailscale/rootfs/usr/bin/subnet-routes
+++ b/tailscale/rootfs/usr/bin/subnet-routes
@@ -16,7 +16,7 @@ function appendarray() {
 }
 
 if ! [[ "${1-}" =~ ^(local|advertised)$ ]]; then
-  echo "Usage: subnet-routes local|advertised" 1>&2
+  echo "Usage: $(basename "$0") local|advertised" 1>&2
   exit 1
 fi
 

--- a/tailscale/rootfs/usr/bin/unprotect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/unprotect-subnet-routes
@@ -13,7 +13,7 @@ if bashio::config.false "userspace_networking" && \
   (! bashio::config.has_value "accept_routes" || bashio::config.true "accept_routes")
 then
   if ! [[ "${1-}" =~ ^(|test)$ ]]; then
-    echo "Usage: unprotect-subnet-routes [test]" 1>&2
+    echo "Usage: $(basename "$0") [test]" 1>&2
     exit 1
   fi
 

--- a/tailscale/rootfs/usr/bin/unprotect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/unprotect-subnet-routes
@@ -23,7 +23,7 @@ then
     | sed -nr 's/^\d+:\s+from all to ([^\s]+) lookup main$/\1/p')
 
   if [[ "${1-}" == "test" ]]; then
-    printf "%s\n" "${routes[@]}"
+    printf "%s" "${routes[@]/%/$'\n'}"
   else
     for route in "${routes[@]}"; do
       bashio::log.info "Removing route ${route} from ip rules"

--- a/tailscale/rootfs/usr/bin/unprotect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/unprotect-subnet-routes
@@ -23,7 +23,7 @@ then
     | sed -nr 's/^\d+:\s+from all to ([^\s]+) lookup main$/\1/p')
 
   if [[ "${1-}" == "test" ]]; then
-    printf "%s" "${routes[@]/%/$'\n'}"
+    printf "%s\n" "${routes[@]}"
   else
     for route in "${routes[@]}"; do
       bashio::log.info "Removing route ${route} from ip rules"

--- a/tailscale/rootfs/usr/bin/unprotect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/unprotect-subnet-routes
@@ -12,17 +12,27 @@ declare route family
 if bashio::config.false "userspace_networking" && \
   (! bashio::config.has_value "accept_routes" || bashio::config.true "accept_routes")
 then
+  if ! [[ "${1-}" =~ ^(|test)$ ]]; then
+    echo "Usage: unprotect-subnet-routes [test]" 1>&2
+    exit 1
+  fi
+
   readarray -t routes < <( \
     { ip -4 rule list; ip -6 rule list; } \
     | { grep -E "^${PROTECTION_RULE_PRIORITY}:" || true ;} \
     | sed -nr 's/^\d+:\s+from all to ([^\s]+) lookup main$/\1/p')
-  for route in "${routes[@]}"; do
-    bashio::log.info "Removing route ${route} from ip rules"
-    if [[ "${route}" =~ .*:.* ]]; then
-      family="-6"
-    else
-      family="-4"
-    fi
-    ip "${family}" rule del to "${route}"
-  done
+
+  if [[ "${1-}" == "test" ]]; then
+    printf "%s" "${routes[@]/%/$'\n'}"
+  else
+    for route in "${routes[@]}"; do
+      bashio::log.info "Removing route ${route} from ip rules"
+      if [[ "${route}" =~ .*:.* ]]; then
+        family="-6"
+      else
+        family="-4"
+      fi
+      ip "${family}" rule del to "${route}"
+    done
+  fi
 fi

--- a/tailscale/rootfs/usr/bin/unprotect-subnet-routes
+++ b/tailscale/rootfs/usr/bin/unprotect-subnet-routes
@@ -9,30 +9,26 @@ readonly PROTECTION_RULE_PRIORITY=5000
 declare -a routes=()
 declare route family
 
-if bashio::config.false "userspace_networking" && \
-  (! bashio::config.has_value "accept_routes" || bashio::config.true "accept_routes")
-then
-  if ! [[ "${1-}" =~ ^(|test)$ ]]; then
-    echo "Usage: $(basename "$0") [test]" 1>&2
-    exit 1
-  fi
+if ! [[ "${1-}" =~ ^(|test)$ ]]; then
+  echo "Usage: $(basename "$0") [test]" 1>&2
+  exit 1
+fi
 
-  readarray -t routes < <( \
-    { ip -4 rule list; ip -6 rule list; } \
-    | { grep -E "^${PROTECTION_RULE_PRIORITY}:" || true ;} \
-    | sed -nr 's/^\d+:\s+from all to ([^\s]+) lookup main$/\1/p')
+readarray -t routes < <( \
+  { ip -4 rule list; ip -6 rule list; } \
+  | { grep -E "^${PROTECTION_RULE_PRIORITY}:" || true ;} \
+  | sed -nr 's/^\d+:\s+from all to ([^\s]+) lookup main$/\1/p')
 
-  if [[ "${1-}" == "test" ]]; then
-    printf "%s" "${routes[@]/%/$'\n'}"
-  else
-    for route in "${routes[@]}"; do
-      bashio::log.info "Removing route ${route} from ip rules"
-      if [[ "${route}" =~ .*:.* ]]; then
-        family="-6"
-      else
-        family="-4"
-      fi
-      ip "${family}" rule del to "${route}"
-    done
-  fi
+if [[ "${1-}" == "test" ]]; then
+  printf "%s" "${routes[@]/%/$'\n'}"
+else
+  for route in "${routes[@]}"; do
+    bashio::log.info "Removing route ${route} from ip rules"
+    if [[ "${route}" =~ .*:.* ]]; then
+      family="-6"
+    else
+      family="-4"
+    fi
+    ip "${family}" rule del to "${route}"
+  done
 fi


### PR DESCRIPTION
# Proposed Changes

It spammed the log and modified iptables unnecessarily on each dhcpX-change Network Manager action (eg. each 30-60 minutes, depending on the DHCP server settings).

With this modification it first checks whether subnets has changed at all and does nothing if no real change happened.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dry-run/test modes for subnet protect/unprotect commands to preview actions without applying them.

- **Improvements**
  - Smarter handling of network/DHCP events to avoid unnecessary route changes.
  - Reliable wait-and-retry behavior before applying routes to ensure dependencies are ready.
  - Stable rule priority to prevent routing conflicts.
  - Better argument validation and clearer usage messages.
  - Improved logging and error handling when protecting/unprotecting routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->