### PR TITLE
Update tailscale to v1.84.0

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
 ARG BUILD_ARCH=amd64
-ARG TAILSCALE_VERSION="v1.82.5"
+ARG TAILSCALE_VERSION="v1.84.0"
 RUN \
     apk add --no-cache \
         ethtool=6.11-r0 \


### PR DESCRIPTION
## Proposed Changes

> pull in several bugfixes since the old v1.80.0 that is used in ha's production release addon repo



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Tailscale version used in the Docker image to v1.84.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->