### PR TITLE
Update tailscale/tailscale to v1.84.0

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
 ARG BUILD_ARCH=amd64
-ARG TAILSCALE_VERSION="v1.82.5"
+ARG TAILSCALE_VERSION="v1.84.0"
 RUN \
     apk add --no-cache \
         ethtool=6.14.1-r0 \


### PR DESCRIPTION
# Proposed Changes

For some reasons the v1.84.0 bump was skipped but it's available for all supported platforms, so here it is.